### PR TITLE
convenient interface

### DIFF
--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -487,25 +487,26 @@ def get_deployment_timeseries(evaler, fac_list=[]):
     """
 
     # Get inventory table
-    agents = evaler.eval('AgentEntry')
+    df = evaler.eval('AgentEntry')
 
+    rdc_list = []  # because we want to get reed of the facility asap
     if len(fac_list) != 0:
-        agents = agents[agents['Prototype'].isin(fac_list)]
-        rdc_list.append(['AgentId', agents['AgentId'].tolist()])
+        df = df[df['Prototype'].isin(fac_list)]
+        rdc_list.append(['AgentId', df['AgentId'].tolist()])
     else:
         wng_msg = "no faciity provided"
         warnings.warn(wng_msg, UserWarning)
 
     # Adding a constante column to easely sum the amount of facilities build per
     # time step
-    agents['Value'] = 1
+    df = df.assign(Value = lambda x: 1)
 
     group_end = ['EnterTime']
     group_start = group_end + ['Value']
-    agents = agents[group_start].groupby(group_end).sum()
-    agents.reset_index(inplace=True)
+    df = df[group_start].groupby(group_end).sum()
+    df.reset_index(inplace=True)
 
-    return inv
+    return df
 
 
 def get_retirement_timeseries(evaler, fac_list=[]):
@@ -519,11 +520,13 @@ def get_retirement_timeseries(evaler, fac_list=[]):
     """
 
     # Get inventory table
-    agents = evaler.eval('AgentEntry')
-    agents = agents[agenst['LifeTime'] > 0]
+    df = evaler.eval('AgentEntry')
+    df = df[df['Lifetime'] > 0]
+    
+    rdc_list = []  # because we want to get reed of the facility asap
     if len(fac_list) != 0:
-        agents = agents[agents['Prototype'].isin(fac_list)]
-        rdc_list.append(['AgentId', agents['AgentId'].tolist()])
+        df = df[df['Prototype'].isin(fac_list)]
+        rdc_list.append(['AgentId', df['AgentId'].tolist()])
     else:
         wng_msg = "no faciity provided"
         warnings.warn(wng_msg, UserWarning)
@@ -531,14 +534,15 @@ def get_retirement_timeseries(evaler, fac_list=[]):
     # Adding a constante column to easely sum the amount of facilities build per
     # time stepi
 
-    agents['Value'] = 1
-    agents['DecomTime'] = agents['EntryTime'] + agents['LifeTime']
+    df = df.assign(Value = lambda x: 1)
+    
+    df['DecomTime'] = df['EnterTime'] + df['Lifetime']
 
     group_end = ['DecomTime']
     group_start = group_end + ['Value']
-    agents = agents[group_start].groupby(group_end).sum()
-    agents.reset_index(inplace=True)
+    df = df[group_start].groupby(group_end).sum()
+    df.reset_index(inplace=True)
 
-    return inv
+    return df
 
 

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -14,6 +14,14 @@ except ImportError:
     HAVE_PYNE = False
 
 
+def format_nuclist(nuc_list):
+    tools.raise_no_pyne('Unable to format nuclide list!', HAVE_PYNE)
+    
+    for i in range(len(nuc_list)):
+        nuc_list[i] = nucname.id(nuc_list[i])
+
+    return nuc_list
+
 
 def merge_n_drop(pdf, base_col, add_pdf, add_col):
     """
@@ -119,20 +127,16 @@ def get_transaction_nuc_pdf(evaler, send_list=[], rec_list=[], commod_list=[], n
     df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
 
     if len(nuc_list) != 0:
-        for i in range(len(nuc_list)):
-            nuc_list[i] = nucname.id(nuc_list[i])
+        nuc_list = format_nuclist(nuc_list)
 
-        compo = evaler.eval('Materials')
-        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
+    compo = evaler.eval('Materials')
+    compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
 
-        base_col = ['SimId', 'QualId']
-        added_col = base_col + ['NucId', 'Mass']
-        df = merge_n_drop(df, base_col, compo, added_col)
-    else:
-        wng_msg = "no nuclide provided"
-        warnings.warn(wng_msg, UserWarning)
+    base_col = ['SimId', 'QualId']
+    added_col = base_col + ['NucId', 'Mass']
+    df = merge_n_drop(df, base_col, compo, added_col)
 
-    return trans
+    return df
 
 
 def get_transaction_activity_pdf(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
@@ -151,20 +155,16 @@ def get_transaction_activity_pdf(evaler, send_list=[], rec_list=[], commod_list=
     df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
 
     if len(nuc_list) != 0:
-        for i in range(len(nuc_list)):
-            nuc_list[i] = nucname.id(nuc_list[i])
+        nuc_list = format_nuclist(nuc_list)
 
-        compo = evaler.eval('Activity')
-        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
+    compo = evaler.eval('Activity')
+    compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
 
-        base_col = ['SimId', 'QualId']
-        added_col = base_col + ['NucId', 'Activity']
-        df = merge_n_drop(df, base_col, compo, added_col)
-    else:
-        wng_msg = "no nuclide provided"
-        warnings.warn(wng_msg, UserWarning)
+    base_col = ['SimId', 'QualId']
+    added_col = base_col + ['NucId', 'Activity']
+    df = merge_n_drop(df, base_col, compo, added_col)
 
-    return trans
+    return df
 
 
 def get_transaction_decayheat_pdf(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
@@ -183,20 +183,16 @@ def get_transaction_decayheat_pdf(evaler, send_list=[], rec_list=[], commod_list
     df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
 
     if len(nuc_list) != 0:
-        for i in range(len(nuc_list)):
-            nuc_list[i] = nucname.id(nuc_list[i])
+        nuc_list = format_nuclist(nuc_list)
 
-        compo = evaler.eval('DecayHeat')
-        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
+    compo = evaler.eval('DecayHeat')
+    compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
 
-        base_col = ['SimId', 'QualId']
-        added_col = base_col + ['NucId', 'DecayHeat']
-        df = merge_n_drop(df, base_col, compo, added_col)
-    else:
-        wng_msg = "no nuclide provided"
-        warnings.warn(wng_msg, UserWarning)
+    base_col = ['SimId', 'QualId']
+    added_col = base_col + ['NucId', 'DecayHeat']
+    df = merge_n_drop(df, base_col, compo, added_col)
 
-    return trans
+    return df
 
 
 def get_transaction_timeseries(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
@@ -212,6 +208,9 @@ def get_transaction_timeseries(evaler, send_list=[], rec_list=[], commod_list=[]
     nuc_list : list of nuclide to select.
     """
 
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list)
+
     df = get_transaction_nuc_pdf(evaler, send_list, rec_list, commod_list,
             nuc_list)
 
@@ -219,10 +218,10 @@ def get_transaction_timeseries(evaler, send_list=[], rec_list=[], commod_list=[]
     group_start = group_end + ['Mass']
     df = df[group_start].groupby(group_end).sum()
 
-    trans = df[['Time', 'Mass']].groupby(['Time']).sum()
-    trans.reset_index(inplace=True)
+    df = df[['Time', 'Mass']].groupby(['Time']).sum()
+    df.reset_index(inplace=True)
 
-    return trans
+    return df
 
 
 def get_transaction_activity_timeseries(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
@@ -238,6 +237,9 @@ def get_transaction_activity_timeseries(evaler, send_list=[], rec_list=[], commo
     nuc_list : list of nuclide to select.
     """
 
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list)
+    
     df = get_transaction_activity_pdf(evaler, send_list, rec_list, commod_list,
             nuc_list)
 
@@ -245,10 +247,10 @@ def get_transaction_activity_timeseries(evaler, send_list=[], rec_list=[], commo
     group_start = group_end + ['Activity']
     df = df[group_start].groupby(group_end).sum()
 
-    trans = df[['Time', 'Activity']].groupby(['Time']).sum()
-    trans.reset_index(inplace=True)
+    df = df[['Time', 'Activity']].groupby(['Time']).sum()
+    df.reset_index(inplace=True)
 
-    return trans
+    return df
 
 def get_transaction_decayheat_timeseries(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
@@ -262,6 +264,9 @@ def get_transaction_decayheat_timeseries(evaler, send_list=[], rec_list=[], comm
     commod_list : list of the receiving facility
     nuc_list : list of nuclide to select.
     """
+    
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list) 
 
     df = get_transaction_activity_pdf(evaler, send_list, rec_list, commod_list,
             nuc_list)
@@ -270,10 +275,10 @@ def get_transaction_decayheat_timeseries(evaler, send_list=[], rec_list=[], comm
     group_start = group_end + ['DecayHeat']
     df = df[group_start].groupby(group_end).sum()
 
-    trans = df[['Time', 'DecayHeat']].groupby(['Time']).sum()
-    trans.reset_index(inplace=True)
+    df = df[['Time', 'DecayHeat']].groupby(['Time']).sum()
+    df.reset_index(inplace=True)
 
-    return trans
+    return df
 
 
 def get_inventory_pdf(evaler, fac_list=[], nuc_list=[]):
@@ -293,8 +298,7 @@ def get_inventory_pdf(evaler, fac_list=[], nuc_list=[]):
 
     rdc_list = []  # because we want to get reed of the nuclide asap
     if len(nuc_list) != 0:
-        for i in range(len(nuc_list)):
-            nuc_list[i] = nucname.id(nuc_list[i])
+        nuc_list = format_nuclist(nuc_list)
         rdc_list.append(['NucId', nuc_list])
     else:
         wng_msg = "no nuclide provided"
@@ -326,6 +330,10 @@ def get_inventory_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
+    
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list)
+    
     inv = get_inventory_pdf(evaler, gac_list, nuc_list)
 
     group_end = ['Time']
@@ -447,7 +455,9 @@ def get_inventory_activity_pdf(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
-    tools.raise_no_pyne('Activity could not be computed', HAVE_PYNE)
+    
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list) 
     
     activity = get_inventory_pdf(evaler, fac_list, nuc_list)
     activity.assign( Activity = lambda x: 
@@ -466,6 +476,9 @@ def get_inventory_activity_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
+    
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list) 
     
     activity = get_activity_pdf(evaler, fac_list, nuc_list)
     group_end = ['Time']
@@ -487,8 +500,10 @@ def get_inventory_decayheat_pdf(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
-    tools.raise_no_pyne('Activity could not be computed', HAVE_PYNE)
     
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list)
+      
     decayheat = get_activity_pdf(evaler, fac_list, nuc_list)
     decayheat.assign( DecayHeat = lambda x: 
             data.MeV_per_MJ * decayheat.Activity * data.q_val(nuc))
@@ -507,6 +522,9 @@ def get_inventory_decayheat_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
+    
+    if len(nuc_list) != 0:
+        nuc_list = format_nuclist(nuc_list)
     
     decayheat = get_decayheat_pdf(evaler, fac_list, nuc_list)
     group_end = ['Time']

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -29,8 +29,7 @@ def add_missing_time_step(df, ref_time):
     Parameters
     ----------
     df: Pandas Data Frame
-    ref_time: list of the time step references (should some from TimeStep
-    metrics)
+    ref_time: list of the time step references (Coming from TimeStep metrics)
     """
     ref_time.rename(index=str, columns={'TimeStep': 'Time'}, inplace=True)
 

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -6,6 +6,7 @@ import numpy as np
 import cymetric as cym
 import warnings
 
+
 def merge_n_drop(pdf, base_col, add_pdf, add_col):
     """
     Merge some additionnal columns fram an additionnal Pandas Data Frame
@@ -21,6 +22,7 @@ def merge_n_drop(pdf, base_col, add_pdf, add_col):
     pdf = pd.merge(add_pdf[add_col], pdf, on=base_col)
     pdf.drop(base_col[1], 1)
     return pdf
+
 
 def get_reduced_pdf(pdf, rdc_list):
     """
@@ -39,7 +41,8 @@ def get_reduced_pdf(pdf, rdc_list):
             warnings.warn(wng_msg, UserWarning)
     return pdf
 
-def get_transaction_pdf(db, send_list=[], rec_list=[]):
+
+def get_transaction_pdf(db, send_list=[], rec_list=[], commod_list=[]):
     """
     Filter the Transaction Data Frame on specific sending facility and
     receving facility.
@@ -49,6 +52,7 @@ def get_transaction_pdf(db, send_list=[], rec_list=[]):
     db : database
     send_list : list of the sending facility
     rec_list : list of the receiving facility
+    commod_list : list of the commodity exchanged
     """
 
     # initiate evaluation
@@ -70,8 +74,14 @@ def get_transaction_pdf(db, send_list=[], rec_list=[]):
         return None
     else:
         # Clean Transation PDF
-        trans = get_reduced_pdf(trans, [['ReceiverId', rec_agent['ReceiverId'].tolist()], 
-                                        ['SenderId', send_agent['SenderId'].tolist()]])
+        rdc_list = []
+        rdc_list.append(['ReceiverId', rec_agent['ReceiverId'].tolist()])
+        rdc_list.append(['SenderId',send_agent['SenderId'].tolist()])
+        if len(commod_list) != 0:
+            rdc_list.append(['Commodity',commod_list])
+            
+        trans = get_reduced_pdf(trans, rdc_list )
+
         # Merge Sender to Transaction PDF
         base_col = ['SimId', 'SenderId']
         added_col = base_col + ['Prototype']
@@ -92,7 +102,8 @@ def get_transaction_pdf(db, send_list=[], rec_list=[]):
 
     return trans
 
-def get_transaction_timeseries(db, send_list=[], rec_list=[], nuc_list=[]):
+
+def get_transaction_timeseries(db, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
     Shape the reduced transation Dta Frame into a simple time serie. Apply
     some nuclei selection if required.
@@ -100,12 +111,13 @@ def get_transaction_timeseries(db, send_list=[], rec_list=[], nuc_list=[]):
     Parameters
     ----------
     db : database
-    send_name : name of the sending facility
-    rec_name : name of the receiving facility
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
+    commod_list : list of the receiving facility
     nuc_list : list of nuclide to select.
     """
 
-    df = get_transaction_pdf(db, send_list, rec_list)
+    df = get_transaction_pdf(db, send_list, rec_list, commod_list)
 
     if len(nuc_list) != 0:
         for i in range(len(nuc_list)):
@@ -132,6 +144,7 @@ def get_transaction_timeseries(db, send_list=[], rec_list=[], nuc_list=[]):
     trans.reset_index(inplace=True)
 
     return trans
+
 
 def get_inventory_timeseries(db, fac_list=[], nuc_list=[]):
     """

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -66,7 +66,6 @@ def get_transaction_pdf(evaler, send_list=[], rec_list=[], commod_list=[]):
     # initiate evaluation
     trans = evaler.eval('Transactions')
     agents = evaler.eval('AgentEntry')
-    rsc = evaler.eval('Resources')
 
     rec_agent = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
     if len(rec_list) != 0:
@@ -101,11 +100,101 @@ def get_transaction_pdf(evaler, send_list=[], rec_list=[], commod_list=[]):
         trans = merge_n_drop(trans, base_col, rec_agent, added_col)
         trans = trans.rename(index=str, columns={'Prototype': 'ReceiverProto'})
 
-        # Merge Resource to Transaction PDF
-        rsc = rsc[rsc['ResourceId'].isin(trans.ResourceId)]
-        base_col = ['SimId', 'ResourceId']
-        added_col = base_col + ['QualId'] + ['Quantity'] + ['Units']
-        trans = merge_n_drop(trans, base_col, rsc, added_col)
+    return trans
+
+
+def get_transaction_nuc_pdf(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+    """
+    Shape the reduced transation Dta Frame into a simple time serie. Applying nuclides selection when required.
+
+    Parameters
+    ----------
+    evaler : evaler
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
+    commod_list : list of the receiving facility
+    nuc_list : list of nuclide to select.
+    """
+
+    df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
+
+    if len(nuc_list) != 0:
+        for i in range(len(nuc_list)):
+            nuc_list[i] = nucname.id(nuc_list[i])
+
+        compo = evaler.eval('Materials')
+        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
+
+        base_col = ['SimId', 'QualId']
+        added_col = base_col + ['NucId', 'Mass']
+        df = merge_n_drop(df, base_col, compo, added_col)
+    else:
+        wng_msg = "no nuclide provided"
+        warnings.warn(wng_msg, UserWarning)
+
+    return trans
+
+
+def get_transaction_activity_pdf(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+    """
+    Return the transation pdf, with the activities. Applying nuclides selection when required.
+
+    Parameters
+    ----------
+    evaler : evaler
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
+    commod_list : list of the receiving facility
+    nuc_list : list of nuclide to select.
+    """
+
+    df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
+
+    if len(nuc_list) != 0:
+        for i in range(len(nuc_list)):
+            nuc_list[i] = nucname.id(nuc_list[i])
+
+        compo = evaler.eval('Activity')
+        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
+
+        base_col = ['SimId', 'QualId']
+        added_col = base_col + ['NucId', 'Activity']
+        df = merge_n_drop(df, base_col, compo, added_col)
+    else:
+        wng_msg = "no nuclide provided"
+        warnings.warn(wng_msg, UserWarning)
+
+    return trans
+
+
+def get_transaction_decayheat_pdf(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+    """
+    Return the transation pdf, with the decayheat. Applying nuclides selection when required.
+
+    Parameters
+    ----------
+    evaler : evaler
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
+    commod_list : list of the receiving facility
+    nuc_list : list of nuclide to select.
+    """
+
+    df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
+
+    if len(nuc_list) != 0:
+        for i in range(len(nuc_list)):
+            nuc_list[i] = nucname.id(nuc_list[i])
+
+        compo = evaler.eval('DecayHeat')
+        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
+
+        base_col = ['SimId', 'QualId']
+        added_col = base_col + ['NucId', 'DecayHeat']
+        df = merge_n_drop(df, base_col, compo, added_col)
+    else:
+        wng_msg = "no nuclide provided"
+        warnings.warn(wng_msg, UserWarning)
 
     return trans
 
@@ -123,34 +212,68 @@ def get_transaction_timeseries(evaler, send_list=[], rec_list=[], commod_list=[]
     nuc_list : list of nuclide to select.
     """
 
-    tools.raise_no_pyne('Activity could not be computed', HAVE_PYNE)
-    df = get_transaction_pdf(evaler, send_list, rec_list, commod_list)
+    df = get_transaction_nuc_pdf(evaler, send_list, rec_list, commod_list,
+            nuc_list)
 
-    if len(nuc_list) != 0:
-        for i in range(len(nuc_list)):
-            nuc_list[i] = nucname.id(nuc_list[i])
+    group_end = ['ReceiverProto', 'SenderProto', 'Time']
+    group_start = group_end + ['Mass']
+    df = df[group_start].groupby(group_end).sum()
 
-        compo = evaler.eval('Compositions')
-        compo = get_reduced_pdf(compo, [['NucId', nuc_list]])
-
-        base_col = ['SimId', 'QualId']
-        added_col = base_col + ['NucId', 'MassFrac']
-        df = merge_n_drop(df, base_col, compo, added_col)
-
-        df['Quantity'] = df['Quantity'] * df['MassFrac']
-
-        group_end = ['ReceiverProto', 'SenderProto', 'Time']
-        group_start = group_end + ['Quantity']
-        df = df[group_start].groupby(group_end).sum()
-    else:
-        wng_msg = "no nuclide provided"
-        warnings.warn(wng_msg, UserWarning)
-
-    trans = df[['Time', 'Quantity']].groupby(['Time']).sum()
+    trans = df[['Time', 'Mass']].groupby(['Time']).sum()
     trans.reset_index(inplace=True)
 
     return trans
 
+
+def get_transaction_activity_timeseries(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+    """
+    Shape the reduced transation Dta Frame into a simple time serie. Applying nuclides selection when required.
+
+    Parameters
+    ----------
+    evaler : evaler
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
+    commod_list : list of the receiving facility
+    nuc_list : list of nuclide to select.
+    """
+
+    df = get_transaction_activity_pdf(evaler, send_list, rec_list, commod_list,
+            nuc_list)
+
+    group_end = ['ReceiverProto', 'SenderProto', 'Time']
+    group_start = group_end + ['Activity']
+    df = df[group_start].groupby(group_end).sum()
+
+    trans = df[['Time', 'Activity']].groupby(['Time']).sum()
+    trans.reset_index(inplace=True)
+
+    return trans
+
+def get_transaction_decayheat_timeseries(evaler, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+    """
+    Shape the reduced transation Dta Frame into a simple time serie. Applying nuclides selection when required.
+
+    Parameters
+    ----------
+    evaler : evaler
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
+    commod_list : list of the receiving facility
+    nuc_list : list of nuclide to select.
+    """
+
+    df = get_transaction_activity_pdf(evaler, send_list, rec_list, commod_list,
+            nuc_list)
+
+    group_end = ['ReceiverProto', 'SenderProto', 'Time']
+    group_start = group_end + ['DecayHeat']
+    df = df[group_start].groupby(group_end).sum()
+
+    trans = df[['Time', 'DecayHeat']].groupby(['Time']).sum()
+    trans.reset_index(inplace=True)
+
+    return trans
 
 
 def get_inventory_pdf(evaler, fac_list=[], nuc_list=[]):
@@ -164,7 +287,6 @@ def get_inventory_pdf(evaler, fac_list=[], nuc_list=[]):
     nuc_list : list of nuclide to select.
     """
 
-    tools.raise_no_pyne('Activity could not be computed', HAVE_PYNE)
     # Get inventory table
     inv = evaler.eval('ExplicitInventory')
     agents = evaler.eval('AgentEntry')
@@ -204,7 +326,6 @@ def get_inventory_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
-    tools.raise_no_pyne('Activity could not be computed', HAVE_PYNE)
     inv = get_inventory_pdf(evaler, gac_list, nuc_list)
 
     group_end = ['Time']
@@ -315,7 +436,7 @@ def get_retirement_timeseries(evaler, fac_list=[]):
     return inv
 
 
-def get_activity_pdf(evaler, fac_list=[], nuc_list=[]):
+def get_inventory_activity_pdf(evaler, fac_list=[], nuc_list=[]):
     """
     Get a simple time series of the activity of the inventory in the selcted
     facilities. Applying nuclides selection when required.
@@ -334,7 +455,7 @@ def get_activity_pdf(evaler, fac_list=[], nuc_list=[]):
     
     return activity
 
-def get_activity_timeseries(evaler, fac_list=[], nuc_list=[]):
+def get_inventory_activity_timeseries(evaler, fac_list=[], nuc_list=[]):
     """
     Get a simple time series of the decay heat of the inventory in the selcted
     facilities. Applying nuclides selection when required.
@@ -355,7 +476,7 @@ def get_activity_timeseries(evaler, fac_list=[], nuc_list=[]):
     return activity
 
 
-def get_decayheat_pdf(evaler, fac_list=[], nuc_list=[]):
+def get_inventory_decayheat_pdf(evaler, fac_list=[], nuc_list=[]):
     """
     Get a Inventory PDF including the decay heat of the inventory in the selected
     facilities. Applying nuclides selection when required.
@@ -375,7 +496,7 @@ def get_decayheat_pdf(evaler, fac_list=[], nuc_list=[]):
     return decayheat
 
 
-def get_decayheat_timeseries(evaler, fac_list=[], nuc_list=[]):
+def get_inventory_decayheat_timeseries(evaler, fac_list=[], nuc_list=[]):
     """
     Get a simple time series of the decay heat of the inventory in the selcted
     facilities. Applying nuclides selection when required.

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -215,7 +215,7 @@ def get_transaction_decayheat_df(evaler_, send_list=[], rec_list=[], commod_list
 
 def get_transaction_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
-    Shape the reduced transation Dta Frame into a simple time serie. Applying nuclides selection when required.
+    Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
 
     Parameters
     ----------
@@ -247,7 +247,7 @@ def get_transaction_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[
 
 def get_transaction_activity_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
-    Shape the reduced transation Dta Frame into a simple time serie. Applying nuclides selection when required.
+    Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
 
     Parameters
     ----------
@@ -279,7 +279,7 @@ def get_transaction_activity_timeseries(evaler_, send_list=[], rec_list=[], comm
 
 def get_transaction_decayheat_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
-    Shape the reduced transation Dta Frame into a simple time serie. Applying nuclides selection when required.
+    Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
 
     Parameters
     ----------

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -215,7 +215,7 @@ def get_transaction_decayheat_df(evaler_, send_list=[], rec_list=[], commod_list
     return df
 
 
-def get_transaction_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+def get_transaction_timeserie(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
     Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
 
@@ -247,7 +247,7 @@ def get_transaction_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[
     return df
 
 
-def get_transaction_activity_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+def get_transaction_activity_timeserie(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
     Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
 
@@ -279,7 +279,7 @@ def get_transaction_activity_timeseries(evaler_, send_list=[], rec_list=[], comm
     return df
 
 
-def get_transaction_decayheat_timeseries(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
+def get_transaction_decayheat_timeserie(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
     Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
 
@@ -349,7 +349,7 @@ def get_inventory_df(evaler_, fac_list=[], nuc_list=[]):
     return df
 
 
-def get_inventory_timeseries(evaler_, fac_list=[], nuc_list=[]):
+def get_inventory_timeserie(evaler_, fac_list=[], nuc_list=[]):
     """
     Shape the reduced inventory Data Frame into a simple time serie. Applying
     nuclides/facilities selection when required.
@@ -400,7 +400,7 @@ def get_inventory_activity_df(evaler_, fac_list=[], nuc_list=[]):
     return df
 
 
-def get_inventory_activity_timeseries(evaler_, fac_list=[], nuc_list=[]):
+def get_inventory_activity_timeserie(evaler_, fac_list=[], nuc_list=[]):
     """
     Get a simple time series of the decay heat of the inventory in the selcted
     facilities. Applying nuclides selection when required.
@@ -415,15 +415,15 @@ def get_inventory_activity_timeseries(evaler_, fac_list=[], nuc_list=[]):
     if len(nuc_list) != 0:
         nuc_list = format_nuclist(nuc_list)
 
-    activity = get_inventory_activity_df(evaler_, fac_list, nuc_list)
+    df = get_inventory_activity_df(evaler_, fac_list, nuc_list)
     group_end = ['Time']
     group_start = group_end + ['Activity']
-    activity = activity[group_start].groupby(group_end).sum()
-    activity.reset_index(inplace=True)
+    df = df[group_start].groupby(group_end).sum()
+    df.reset_index(inplace=True)
 
     time = evaler_.eval('TimeList')
     df = add_missing_time_step(df, time)
-    return activity
+    return df
 
 
 def get_inventory_decayheat_df(evaler_, fac_list=[], nuc_list=[]):
@@ -450,7 +450,7 @@ def get_inventory_decayheat_df(evaler_, fac_list=[], nuc_list=[]):
     return df
 
 
-def get_inventory_decayheat_timeseries(evaler_, fac_list=[], nuc_list=[]):
+def get_inventory_decayheat_timeserie(evaler_, fac_list=[], nuc_list=[]):
     """
     Get a simple time series of the decay heat of the inventory in the selcted
     facilities. Applying nuclides selection when required.
@@ -465,18 +465,18 @@ def get_inventory_decayheat_timeseries(evaler_, fac_list=[], nuc_list=[]):
     if len(nuc_list) != 0:
         nuc_list = format_nuclist(nuc_list)
 
-    decayheat = get_inventory_decayheat_df(evaler_, fac_list, nuc_list)
+    df = get_inventory_decayheat_df(evaler_, fac_list, nuc_list)
     group_end = ['Time']
     group_start = group_end + ['DecayHeat']
-    decayheat = decayheat[group_start].groupby(group_end).sum()
-    decayheat.reset_index(inplace=True)
+    df = df[group_start].groupby(group_end).sum()
+    df.reset_index(inplace=True)
 
     time = evaler_.eval('TimeList')
     df = add_missing_time_step(df, time)
-    return decayheat
+    return df
 
 
-def get_power_timeseries(evaler_, fac_list=[]):
+def get_power_timeserie(evaler_, fac_list=[]):
     """
     Shape the reduced Power Data Frame into a simple time serie. Applying
     facilities selection when required.
@@ -511,7 +511,7 @@ def get_power_timeseries(evaler_, fac_list=[]):
     return df
 
 
-def get_deployment_timeseries(evaler_, fac_list=[]):
+def get_deployment_timeserie(evaler_, fac_list=[]):
     """
     Get a simple time series with deployment schedule of the selected facilities.
 
@@ -546,7 +546,7 @@ def get_deployment_timeseries(evaler_, fac_list=[]):
     return df
 
 
-def get_retirement_timeseries(evaler_, fac_list=[]):
+def get_retirement_timeserie(evaler_, fac_list=[]):
     """
     Get a simple time series with retirement schedule of the selected facilities.
 

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -8,58 +8,54 @@ import warnings
 
 
 def merge_n_drop(pdf, base_col, add_pdf, add_col):
-        """
-        Merge some additionnal columns fram an additionnal Pandas Data Frame
-        onother one and then remove the second base column (keeping SimID
-        information).
-        Parameters
-        ----------
-        pdf : Pandas Data Frame
-        base_col : list of the base columns names
-        add_pdf : Pandas Data Frame to add in the pdf one
-        add_col : columns tobe added
-
-        Attributes
-        ----------
-        """
+    """
+    Merge some additionnal columns fram an additionnal Pandas Data Frame
+    onother one and then remove the second base column (keeping SimID
+    information).
+    Parameters
+    ----------
+    pdf : Pandas Data Frame
+    base_col : list of the base columns names
+    add_pdf : Pandas Data Frame to add in the pdf one
+    add_col : columns tobe added
+    """
     pdf = pd.merge(add_pdf[add_col], pdf, on=base_col)
     pdf.drop(base_col[1], 1)
     return pdf
 
 def get_reduced_pdf(pdf, rdc_list):
-        """
-        Filter the pdf Pandas Data Frame according to the rdc_list (list of item
-        in the corresponding columns).
-        Parameters
-        ----------
-        pdf : Pandas Data Frame
-        rdc_list : list of pair of string and string list.
-
-        Attributes
-        ----------
-        """
+    """
+    Filter the pdf Pandas Data Frame according to the rdc_list (list of item
+    in the corresponding columns).
+    Parameters
+    ----------
+    pdf : Pandas Data Frame
+    rdc_list : list of pair of string and string list.
+    """
     for rdc in rdc_list:
         if len(rdc[1]) != 0:
-            pdf = pdf.loc[compo[rdc[0].isin(rdc[1])]
+            print(rdc[0])
+            print(rdc[1])
+            pdf = pdf[ pdf[rdc[0]].isin(rdc[1]) ]
         else:
             wng_msg = "Empty list provided for " + rdc[0] + " key."
             warnings.wrn(wng_msg, UserWarning)
     return pdf
 
 def get_reduced__trans_pdf(db, send_name, rec_name):
-        """
-        Filter the Transaction Data Frame on specific sending facility and
-        receving facility.
+    """
+    Filter the Transaction Data Frame on specific sending facility and
+    receving facility.
 
-        Parameters
-        ----------
-        db : database
-        send_name : name of the sending facility ('All' for any)
-        rec_name : name of the receiving facility ('All for any)
+    Parameters
+    ----------
+    db : database
+    send_name : name of the sending facility ('All' for any)
+    rec_name : name of the receiving facility ('All for any)
 
-        Attributes
-        ----------
-        """
+    Attributes
+    ----------
+    """
 
     # initiate evaluation
     evaler = cym.Evaluator(db)
@@ -79,19 +75,20 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
     if rec_list.empty or send_list.empty:
         return None
     else:
-        trans = get_reduced_pdf(trans, [[['ReceiverId',[rec_list.ReceiveriId]],
-                                        [['SenderId',[SenderId]]])
-        rsc = rsc.loc[rsc['ResourceId'].isin(trans.ResourceId)]
+        trans = get_reduced_pdf(trans, [
+            ['ReceiverId', rec_list['ReceiverId'].tolist() ],
+            ['SenderId', send_list['SenderId'].tolist() ] ])
+        rsc = rsc[ rsc['ResourceId'].isin( trans.ResourceId ) ]
 
         base_col = ['SimId', 'SenderId']
         added_col = base_col + ['Prototype']
         trans = merge_n_drop(trans, base_col, send_list, added_col)
-        trans = df.rename(index=str, columns={'Prototype': 'SenderProto'})
+        trans = trans.rename(index=str, columns={'Prototype': 'SenderProto'})
 
         base_col = ['SimId', 'ReceiverId']
         added_col = base_col + ['Prototype']
         trans = merge_n_drop(trans, base_col, send_list, added_col)
-        trans = df.rename(index=str, columns={'Prototype': 'ReceiverProto'})
+        trans = trans.rename(index=str, columns={'Prototype': 'ReceiverProto'})
 
         base_col = ['SimId', 'RessourceId']
         added_col = base_col + ['QualId', 'Quantity', 'Unit']
@@ -100,23 +97,20 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
     return trans
 
 
-def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list):
-        """
-        Shape the reduced transation Dta Frame into a simple time serie. Apply
-        some nuclei selection if required.
+def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list=[]):
+    """
+    Shape the reduced transation Dta Frame into a simple time serie. Apply
+    some nuclei selection if required.
 
-        Parameters
-        ----------
-        db : database
-        send_name : name of the sending facility
-        rec_name : name of the receiving facility
-        nuc_list : list of nuclide to select.
+    Parameters
+    ----------
+    db : database
+    send_name : name of the sending facility
+    rec_name : name of the receiving facility
+    nuc_list : list of nuclide to select.
+    """
 
-        Attributes
-        ----------
-        """
-
-    df = get_transaction_timeseries(db, send_name, rec_name)
+    df = get_reduced__trans_pdf(db, send_name, rec_name)
 
     if len(nuc_list) != 0:
         compo = evaler.eval('Compositions')
@@ -152,20 +146,17 @@ def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list):
     return trans_table
 
 
-def GetInventoryTimeSeries(db, fac_name, nuc_list):
-        """
-        Shape the reduced inventory Dta Frame into a simple time serie. Apply
-        some nuclei selection if required.
+def get_inventory_timeseries(db, fac_name, nuc_list):
+    """
+    Shape the reduced inventory Dta Frame into a simple time serie. Apply
+    some nuclei selection if required.
 
-        Parameters
-        ----------
-        db : database
-        fac_name : name of the facility
-        nuc_list : list of nuclide to select.
-
-        Attributes
-        ----------
-        """
+    Parameters
+    ----------
+    db : database
+    fac_name : name of the facility
+    nuc_list : list of nuclide to select.
+    """
     evaler = cym.Evaluator(db)
 
     # Get inventory table

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -36,10 +36,10 @@ def get_reduced_pdf(pdf, rdc_list):
             pdf = pdf[pdf[rdc[0]].isin(rdc[1])]
         else:
             wng_msg = "Empty list provided for " + rdc[0] + " key."
-            warnings.wrn(wng_msg, UserWarning)
+            warnings.warn(wng_msg, UserWarning)
     return pdf
 
-def get_reduced__trans_pdf(db, send_name, rec_name):
+def get_transaction_pdf(db, send_list=[], rec_list=[]):
     """
     Filter the Transaction Data Frame on specific sending facility and
     receving facility.
@@ -47,8 +47,8 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
     Parameters
     ----------
     db : database
-    send_name : name of the sending facility ('All' for any)
-    rec_name : name of the receiving facility ('All for any)
+    send_list : list of the sending facility
+    rec_list : list of the receiving facility
     """
 
     # initiate evaluation
@@ -57,39 +57,42 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
     agents = evaler.eval('AgentEntry')
     rsc = evaler.eval('Resources')
 
-    rec_list = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
-    if rec_name != 'All':
-        rec_list = rec_list.loc[lambda df: df.Prototype == rec_name, :]
+    rec_agent = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
+    if len(rec_list) != 0:
+        rec_agent = rec_agent[rec_agent['Prototype'].isin(rec_list)]
 
-    send_list = agents.rename(index=str, columns={'AgentId': 'SenderId'})
-    if send_name != 'All':
-        send_list = send_list.loc[lambda df: df.Prototype == send_name, :]
+    send_agent = agents.rename(index=str, columns={'AgentId': 'SenderId'})
+    if len(send_list) != 0:
+        send_agent = send_agent[send_agent['Prototype'].isin(send_list)]
 
     # check if sender and receiver exist
-    if rec_list.empty or send_list.empty:
+    if rec_agent.empty or send_agent.empty:
         return None
     else:
-        trans = get_reduced_pdf(trans, [['ReceiverId', rec_list['ReceiverId'].tolist()], [
-                                'SenderId', send_list['SenderId'].tolist()]])
-        rsc = rsc[rsc['ResourceId'].isin(trans.ResourceId)]
-
+        # Clean Transation PDF
+        trans = get_reduced_pdf(trans, [['ReceiverId', rec_agent['ReceiverId'].tolist()], 
+                                        ['SenderId', send_agent['SenderId'].tolist()]])
+        # Merge Sender to Transaction PDF
         base_col = ['SimId', 'SenderId']
         added_col = base_col + ['Prototype']
-        trans = merge_n_drop(trans, base_col, send_list, added_col)
+        trans = merge_n_drop(trans, base_col, send_agent, added_col)
         trans = trans.rename(index=str, columns={'Prototype': 'SenderProto'})
 
+        # Merge Receiver to Transaction PDF
         base_col = ['SimId', 'ReceiverId']
         added_col = base_col + ['Prototype']
-        trans = merge_n_drop(trans, base_col, rec_list, added_col)
+        trans = merge_n_drop(trans, base_col, rec_agent, added_col)
         trans = trans.rename(index=str, columns={'Prototype': 'ReceiverProto'})
 
+        # Merge Resource to Transaction PDF
+        rsc = rsc[rsc['ResourceId'].isin(trans.ResourceId)]
         base_col = ['SimId', 'ResourceId']
         added_col = base_col + ['QualId'] + ['Quantity'] + ['Units']
         trans = merge_n_drop(trans, base_col, rsc, added_col)
 
     return trans
 
-def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list=[]):
+def get_transaction_timeseries(db, send_list=[], rec_list=[], nuc_list=[]):
     """
     Shape the reduced transation Dta Frame into a simple time serie. Apply
     some nuclei selection if required.
@@ -102,7 +105,7 @@ def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list=[])
     nuc_list : list of nuclide to select.
     """
 
-    df = get_reduced__trans_pdf(db, send_name, rec_name)
+    df = get_transaction_pdf(db, send_list, rec_list)
 
     if len(nuc_list) != 0:
         for i in range(len(nuc_list)):
@@ -123,26 +126,14 @@ def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list=[])
         df = df[group_start].groupby(group_end).sum()
     else:
         wng_msg = "no nuclide provided"
-        warnings.wrn(wng_msg, UserWarning)
+        warnings.warn(wng_msg, UserWarning)
+        
+    trans = df[['Time', 'Quantity']].groupby(['Time']).sum()
+    trans.reset_index(inplace=True)
 
-    if send_name == 'All':
-        grouped_trans = df[['ReceiverProto', 'Time', 'Quantity']].groupby(
-            ['ReceiverProto', 'Time']).sum()
-        trans_table = grouped_trans.loc[receiver]
-    elif rec_name == 'All':
-        grouped_trans = df[['SenderProto', 'Time', 'Quantity']].groupby(
-            ['SenderProto', 'Time']).sum()
-        trans_table = grouped_trans.loc[sender]
-    else:
-        df.reset_index(inplace=True)
-        grouped_trans = df[['ReceiverProto', 'SenderProto', 'Time',
-                            'Quantity']].groupby(['ReceiverProto', 'SenderProto',
-                                                  'Time']).sum()
-        trans_table = grouped_trans.loc[rec_name].loc[send_name]
+    return trans
 
-    return trans_table
-
-def get_inventory_timeseries(db, fac_name, nuc_list):
+def get_inventory_timeseries(db, fac_list=[], nuc_list=[]):
     """
     Shape the reduced inventory Data Frame into a simple time serie. Apply
     some nuclei selection if required.
@@ -166,28 +157,28 @@ def get_inventory_timeseries(db, fac_name, nuc_list):
         rdc_list.append(['NucId', nuc_list])
     else:
         wng_msg = "no nuclide provided"
-        warnings.wrn(wng_msg, UserWarning)
+        warnings.warn(wng_msg, UserWarning)
 
-    selected_agents = agents.loc[lambda df: df.Prototype == fac_name, :]
-    if fac_name != 'All':
-        agents = agents.loc[lambda df: df.Prototype == fac_name, :]
+    if len(fac_list) != 0:
+        agents = agents[agents['Prototype'].isin(fac_list)]
         rdc_list.append(['AgentId', agents['AgentId'].tolist()])
     else:
         wng_msg = "no faciity provided"
-        warnings.wrn(wng_msg, UserWarning)
+        warnings.warn(wng_msg, UserWarning)
     inv = get_reduced_pdf(inv, rdc_list)
 
     base_col = ['SimId', 'AgentId']
     added_col = base_col + ['Prototype']
     inv = merge_n_drop(inv, base_col, agents, added_col)
-    group_end = ['Prototype', 'Time']
+    group_end = ['Time']
     group_start = group_end + ['Quantity']
     inv = inv[group_start].groupby(group_end).sum()
     inv.reset_index(inplace=True)
 
     return inv
 
-def get_power_timeseries(db, fac_list = []):
+
+def get_power_timeseries(db, fac_list=[]):
     """
     Shape the reduced Power Data Frame into a simple time serie. Apply
     some facility selection if required.
@@ -213,7 +204,7 @@ def get_power_timeseries(db, fac_list = []):
     base_col = ['SimId', 'AgentId']
     added_col = base_col + ['Prototype']
     power = merge_n_drop(power, base_col, agents, added_col)
-    
+
     group_end = ['Time']
     group_start = group_end + ['Value']
     power = power[group_start].groupby(group_end).sum()

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -17,7 +17,7 @@ except ImportError:
 
 def format_nuclist(nuc_list):
     tools.raise_no_pyne('Unable to format nuclide list!', HAVE_PYNE)
-    
+
     for i in range(len(nuc_list)):
         nuc_list[i] = nucname.id(nuc_list[i])
 
@@ -33,7 +33,7 @@ def add_missing_time_step(df, ref_time):
     metrics)
     """
     ref_time.rename(index=str, columns={'TimeStep': 'Time'}, inplace=True)
-   
+
     print(ref_time.columns.values)
     if 'SimId' in ref_time.columns.values:
         ref_time.drop('SimId', 1, inplace=True)
@@ -259,7 +259,7 @@ def get_transaction_activity_timeseries(evaler, send_list=[], rec_list=[], commo
 
     if len(nuc_list) != 0:
         nuc_list = format_nuclist(nuc_list)
-    
+
     df = get_transaction_activity_df(evaler, send_list, rec_list, commod_list,
             nuc_list)
 
@@ -287,9 +287,9 @@ def get_transaction_decayheat_timeseries(evaler, send_list=[], rec_list=[], comm
     commod_list : list of the receiving facility
     nuc_list : list of nuclide to select.
     """
-    
+
     if len(nuc_list) != 0:
-        nuc_list = format_nuclist(nuc_list) 
+        nuc_list = format_nuclist(nuc_list)
 
     df = get_transaction_decayheat_df(evaler, send_list, rec_list, commod_list,
             nuc_list)
@@ -341,9 +341,9 @@ def get_inventory_df(evaler, fac_list=[], nuc_list=[]):
     base_col = ['SimId', 'AgentId']
     added_col = base_col + ['Prototype']
     df = merge_n_drop(df, base_col, agents, added_col)
-    
+
     return df
-    
+
 
 def get_inventory_timeseries(evaler, fac_list=[], nuc_list=[]):
     """
@@ -356,10 +356,10 @@ def get_inventory_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
-    
+
     if len(nuc_list) != 0:
         nuc_list = format_nuclist(nuc_list)
-    
+
     df = get_inventory_df(evaler, fac_list, nuc_list)
 
     group_end = ['Time']
@@ -407,16 +407,16 @@ def get_inventory_activity_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
-    
+
     if len(nuc_list) != 0:
-        nuc_list = format_nuclist(nuc_list) 
-    
+        nuc_list = format_nuclist(nuc_list)
+
     activity = get_inventory_activity_df(evaler, fac_list, nuc_list)
     group_end = ['Time']
     group_start = group_end + ['Activity']
     activity = activity[group_start].groupby(group_end).sum()
     activity.reset_index(inplace=True)
-    
+
     time = evaler.eval('TimeList')
     df = add_missing_time_step(df,time)
     return activity
@@ -457,16 +457,16 @@ def get_inventory_decayheat_timeseries(evaler, fac_list=[], nuc_list=[]):
     fac_name : name of the facility
     nuc_list : list of nuclide to select.
     """
-    
+
     if len(nuc_list) != 0:
         nuc_list = format_nuclist(nuc_list)
-    
+
     decayheat = get_inventory_decayheat_df(evaler, fac_list, nuc_list)
     group_end = ['Time']
     group_start = group_end + ['DecayHeat']
     decayheat = decayheat[group_start].groupby(group_end).sum()
     decayheat.reset_index(inplace=True)
-    
+
     time = evaler.eval('TimeList')
     df = add_missing_time_step(df,time)
     return decayheat
@@ -557,7 +557,7 @@ def get_retirement_timeseries(evaler, fac_list=[]):
     # Get inventory table
     df = evaler.eval('AgentEntry')
     df = df[df['Lifetime'] > 0]
-    
+
     rdc_list = []  # because we want to get reed of the facility asap
     if len(fac_list) != 0:
         df = df[df['Prototype'].isin(fac_list)]
@@ -570,7 +570,7 @@ def get_retirement_timeseries(evaler, fac_list=[]):
     # time stepi
 
     df = df.assign(Value = lambda x: 1)
-    
+
     df['DecomTime'] = df['EnterTime'] + df['Lifetime']
 
     group_end = ['DecomTime']
@@ -582,5 +582,4 @@ def get_retirement_timeseries(evaler, fac_list=[]):
     time = evaler.eval('TimeList')
     df = add_missing_time_step(df,time)
     return df
-
 

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -1,0 +1,126 @@
+from pyne import nucname
+import pandas as pd
+import numpy as np
+import cymetric as cym
+
+def GetTransactionTimeSerie(db, sender='None', receiver='None', *xargs):
+
+  if sender == 'None' and receiver == 'None':
+    print( " Please choose a Receiver or a Sender or both!!")
+    return 0
+  
+  nuc_list = []
+  for inx, nuc in enumerate(xargs):
+    nuc_list.append(nucname.id(nuc))
+
+  #initiate evaluation
+  evaler = cym.Evaluator(db)
+  
+  # get transation & Agent tables
+  trans = evaler.eval('Transactions')
+  agents = evaler.eval('AgentEntry')
+  
+# build 2 table for SenderId and ReceiverId
+  # get receiveri
+  agents_receiver = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
+  if receiver != 'None':
+    agents_receiver_ = agents_receiver.loc[lambda df: df.Prototype == receiver,:]
+    # check if receiver exists
+    if agents_receiver_.empty:
+      print("unknown Receiver, available Receiver are:")
+      for receiver_name in agents_receiver.Prototype.unique(): #check if the loop is correct should it not be trans.XX.XX
+        print(receiver_name)
+    else:
+      agents_receiver = agents_receiver_
+
+
+  # get sender
+  agents_sender = agents.rename(index=str, columns={'AgentId': 'SenderId'})
+  if sender != 'None':
+    agents_sender_ = agents_sender.loc[lambda df: df.Prototype == sender,:]
+    # check if sender exists
+    if agents_sender_.empty:
+      print("unknown Sender, available Sender are:")
+      for sender_name in agents_sender.Prototype.unique():
+        print(sender_name)
+    else:
+      agents_sender = agents_sender_
+
+  #check if seider and receiver exist
+  if( agents_sender.empty or agents_receiver.empty):
+    return 0
+  else: 
+  # Both receiver and sender exist:
+    # select good corresponding transaction
+    selected_trans = trans.loc[trans['ReceiverId'].isin(agents_receiver.ReceiverId)]
+    selected_trans = selected_trans.loc[selected_trans['SenderId'].isin(agents_sender.SenderId)]
+    
+    # Merge Sender infos
+    df = pd.merge(agents_sender[['SimId', 'SenderId', 'Prototype']], selected_trans, on=['SimId', 'SenderId'])
+    df = df.rename(index=str, columns={'Prototype': 'SenderProto'})
+    df = df.drop('SenderId',1)
+    
+    # Merge reveiver infos
+    df = pd.merge(agents_receiver[['SimId', 'ReceiverId', 'Prototype']], df, on=['SimId', 'ReceiverId'])
+    df = df.rename(index=str, columns={'Prototype': 'ReceiverProto'})
+    df = df.drop('ReceiverId',1)
+
+    # Get resource and select the proper one
+    resource = evaler.eval('Resources')
+    selected_resources = resource.loc[resource['ResourceId'].isin(selected_trans.ResourceId)]
+
+    # merge Resource into transaction
+    df = pd.merge(selected_resources[['SimId', 'ResourceId','QualId','Quantity','Units'  ]], df, on=['SimId', 'ResourceId'])
+    df = df.drop('ResourceId',1)
+
+    if len(nuc_list) != 0: # Nuclide required -> do the Math
+      compo = evaler.eval('Compositions')
+      selected_compo = compo.loc[compo['NucId'].isin(nuc_list)]
+
+      df = pd.merge(selected_compo[['SimId', 'QualId','NucId','MassFrac'  ]], df, on=['SimId', 'QualId'])
+      df['Quantity'] = df['Quantity'] * df['MassFrac']
+    
+    grouped_trans = df[['ReceiverProto', 'SenderProto','Time', 'Quantity']].groupby(['ReceiverProto', 'SenderProto','Time']).sum()
+
+    if sender == 'None':
+      grouped_trans = df[['ReceiverProto','Time', 'Quantity']].groupby(['ReceiverProto','Time']).sum()
+      trans_table = grouped_trans.loc[receiver]
+    elif receiver == 'None':
+      grouped_trans = df[['SenderProto','Time', 'Quantity']].groupby(['SenderProto','Time']).sum()
+      trans_table = grouped_trans.loc[sender]
+    else:
+      trans_table = grouped_trans.loc[receiver].loc[sender]
+  
+  return trans_table
+
+
+def GetInventoryTimeSerie(db, facility, *xargs):
+  
+  nuc_list = []
+  for inx, nuc in enumerate(xargs):
+    nuc_list.append(nucname.id(nuc))
+  
+  #initiate evaluation
+  evaler = cym.Evaluator(db)
+  
+  # Get inventory table
+  inv = evaler.eval('ExplicitInventory')
+  if len(nuc_list) != 0 :
+    inv = inv.loc[inv['NucId'].isin(nuc_list)]
+  agents = evaler.eval('AgentEntry')
+
+  selected_agents = agents.loc[lambda df: df.Prototype == facility,:]
+  if selected_agents.empty:
+    print("unknown Facitlity, available Facilities are:")
+    for fac_name in agents.Prototype.unique():
+      print(fac_name)
+    inv_table = 0
+  else:
+    selected_inv = inv.loc[inv['AgentId'].isin(selected_agents.AgentId)]
+    
+    df = pd.merge(selected_agents[['SimId', 'AgentId', 'Prototype']], selected_inv, on=['SimId', 'AgentId'])
+    df = df.drop('AgentId',1)
+    
+    inv_table = df[['Prototype', 'Time','Quantity']].groupby(['Prototype', 'Time']).sum()
+
+  return inv_table

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -34,7 +34,6 @@ def add_missing_time_step(df, ref_time):
     """
     ref_time.rename(index=str, columns={'TimeStep': 'Time'}, inplace=True)
 
-    print(ref_time.columns.values)
     if 'SimId' in ref_time.columns.values:
         ref_time.drop('SimId', 1, inplace=True)
     df = pd.merge(ref_time, df, how="outer")
@@ -488,7 +487,6 @@ def get_power_timeseries(evaler, fac_list=[]):
     agents = evaler.eval('AgentEntry')
 
     rdc_list = []  # because we want to get reed of the facility asap
-    print(fac_list)
     if len(fac_list) != 0:
         agents = agents[agents['Prototype'].isin(fac_list)]
         rdc_list.append(['AgentId', agents['AgentId'].tolist()])
@@ -500,12 +498,12 @@ def get_power_timeseries(evaler, fac_list=[]):
 
     group_end = ['Time']
     group_start = group_end + ['Value']
-    power = power[group_start].groupby(group_end).sum()
-    power.reset_index(inplace=True)
+    df = power[group_start].groupby(group_end).sum()
+    df.reset_index(inplace=True)
 
     time = evaler.eval('TimeList')
     df = add_missing_time_step(df,time)
-    return power
+    return df
 
 
 def get_deployment_timeseries(evaler, fac_list=[]):

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -23,6 +23,7 @@ def merge_n_drop(pdf, base_col, add_pdf, add_col):
     pdf.drop(base_col[1], 1)
     return pdf
 
+
 def get_reduced_pdf(pdf, rdc_list):
     """
     Filter the pdf Pandas Data Frame according to the rdc_list (list of item
@@ -34,11 +35,12 @@ def get_reduced_pdf(pdf, rdc_list):
     """
     for rdc in rdc_list:
         if len(rdc[1]) != 0:
-            pdf = pdf[ pdf[rdc[0]].isin(rdc[1]) ]
+            pdf = pdf[pdf[rdc[0]].isin(rdc[1])]
         else:
             wng_msg = "Empty list provided for " + rdc[0] + " key."
             warnings.wrn(wng_msg, UserWarning)
     return pdf
+
 
 def get_reduced__trans_pdf(db, send_name, rec_name):
     """
@@ -63,20 +65,19 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
 
     rec_list = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
     if rec_name != 'All':
-        rec_list = rec_list.loc[lambda df: df.Prototype == rec_name,:]
-    
+        rec_list = rec_list.loc[lambda df: df.Prototype == rec_name, :]
+
     send_list = agents.rename(index=str, columns={'AgentId': 'SenderId'})
     if send_name != 'All':
-        send_list = send_list.loc[lambda df: df.Prototype == send_name,:]
+        send_list = send_list.loc[lambda df: df.Prototype == send_name, :]
 
     # check if sender and receiver exist
     if rec_list.empty or send_list.empty:
         return None
     else:
-        trans = get_reduced_pdf(trans, [
-            ['ReceiverId', rec_list['ReceiverId'].tolist() ],
-            ['SenderId', send_list['SenderId'].tolist() ] ])
-        rsc = rsc[ rsc['ResourceId'].isin( trans.ResourceId ) ]
+        trans = get_reduced_pdf(trans, [['ReceiverId', rec_list['ReceiverId'].tolist()], [
+                                'SenderId', send_list['SenderId'].tolist()]])
+        rsc = rsc[rsc['ResourceId'].isin(trans.ResourceId)]
 
         base_col = ['SimId', 'SenderId']
         added_col = base_col + ['Prototype']
@@ -89,7 +90,7 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
         trans = trans.rename(index=str, columns={'Prototype': 'ReceiverProto'})
 
         base_col = ['SimId', 'ResourceId']
-        added_col = base_col + ['QualId']+  ['Quantity'] + ['Units']
+        added_col = base_col + ['QualId'] + ['Quantity'] + ['Units']
         trans = merge_n_drop(trans, base_col, rsc, added_col)
 
     return trans
@@ -166,7 +167,7 @@ def get_inventory_timeseries(db, fac_name, nuc_list):
     inv = evaler.eval('ExplicitInventory')
     agents = evaler.eval('AgentEntry')
 
-    rdc_list =[] # because we want to get reed of the nuclide asap
+    rdc_list = []  # because we want to get reed of the nuclide asap
     if len(nuc_list) != 0:
         for i in range(len(nuc_list)):
             nuc_list[i] = nucname.id(nuc_list[i])
@@ -174,17 +175,16 @@ def get_inventory_timeseries(db, fac_name, nuc_list):
     else:
         wng_msg = "no nuclide provided"
         warnings.wrn(wng_msg, UserWarning)
-    
+
     selected_agents = agents.loc[lambda df: df.Prototype == fac_name, :]
     if fac_name != 'All':
-        agents = agents.loc[lambda df: df.Prototype == fac_name,:]
-        rdc_list.append(['AgentId', agents['AgentId'].tolist() ])
+        agents = agents.loc[lambda df: df.Prototype == fac_name, :]
+        rdc_list.append(['AgentId', agents['AgentId'].tolist()])
     else:
         wng_msg = "no faciity provided"
         warnings.wrn(wng_msg, UserWarning)
-
     inv = get_reduced_pdf(inv, rdc_list)
-    
+
     base_col = ['SimId', 'AgentId']
     added_col = base_col + ['Prototype']
     inv = merge_n_drop(inv, base_col, agents, added_col)

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -7,22 +7,59 @@ import cymetric as cym
 import warnings
 
 
-
 def merge_n_drop(pdf, base_col, add_pdf, add_col):
+        """
+        Merge some additionnal columns fram an additionnal Pandas Data Frame
+        onother one and then remove the second base column (keeping SimID
+        information).
+        Parameters
+        ----------
+        pdf : Pandas Data Frame
+        base_col : list of the base columns names
+        add_pdf : Pandas Data Frame to add in the pdf one
+        add_col : columns tobe added
+
+        Attributes
+        ----------
+        """
     pdf = pd.merge(add_pdf[add_col], pdf, on=base_col)
     pdf.drop(base_col[1], 1)
     return pdf
 
-def get_reduced_pdf(db, rdc_list):
+def get_reduced_pdf(pdf, rdc_list):
+        """
+        Filter the pdf Pandas Data Frame according to the rdc_list (list of item
+        in the corresponding columns).
+        Parameters
+        ----------
+        pdf : Pandas Data Frame
+        rdc_list : list of pair of string and string list.
+
+        Attributes
+        ----------
+        """
     for rdc in rdc_list:
         if len(rdc[1]) != 0:
-            db = db.loc[compo[rdc[0].isin(rdc[1])]
+            pdf = pdf.loc[compo[rdc[0].isin(rdc[1])]
         else:
             wng_msg = "Empty list provided for " + rdc[0] + " key."
             warnings.wrn(wng_msg, UserWarning)
-    return db
+    return pdf
 
 def get_reduced__trans_pdf(db, send_name, rec_name):
+        """
+        Filter the Transaction Data Frame on specific sending facility and
+        receving facility.
+
+        Parameters
+        ----------
+        db : database
+        send_name : name of the sending facility ('All' for any)
+        rec_name : name of the receiving facility ('All for any)
+
+        Attributes
+        ----------
+        """
 
     # initiate evaluation
     evaler = cym.Evaluator(db)
@@ -42,8 +79,6 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
     if rec_list.empty or send_list.empty:
         return None
     else:
-        # Both receiver and sender exist:
-
         trans = get_reduced_pdf(trans, [[['ReceiverId',[rec_list.ReceiveriId]],
                                         [['SenderId',[SenderId]]])
         rsc = rsc.loc[rsc['ResourceId'].isin(trans.ResourceId)]
@@ -66,6 +101,20 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
 
 
 def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list):
+        """
+        Shape the reduced transation Dta Frame into a simple time serie. Apply
+        some nuclei selection if required.
+
+        Parameters
+        ----------
+        db : database
+        send_name : name of the sending facility
+        rec_name : name of the receiving facility
+        nuc_list : list of nuclide to select.
+
+        Attributes
+        ----------
+        """
 
     df = get_transaction_timeseries(db, send_name, rec_name)
 
@@ -86,7 +135,6 @@ def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list):
         wng_msg = "no nuclide provided"
         warnings.wrn(wng_msg, UserWarning)
 
-
     if sender == 'All':
         grouped_trans = df[['ReceiverProto', 'Time', 'Quantity']].groupby(
             ['ReceiverProto', 'Time']).sum()
@@ -104,7 +152,20 @@ def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list):
     return trans_table
 
 
-def GetInventoryTimeSeries(db, facility, nuc_list):
+def GetInventoryTimeSeries(db, fac_name, nuc_list):
+        """
+        Shape the reduced inventory Dta Frame into a simple time serie. Apply
+        some nuclei selection if required.
+
+        Parameters
+        ----------
+        db : database
+        fac_name : name of the facility
+        nuc_list : list of nuclide to select.
+
+        Attributes
+        ----------
+        """
     evaler = cym.Evaluator(db)
 
     # Get inventory table
@@ -116,10 +177,9 @@ def GetInventoryTimeSeries(db, facility, nuc_list):
     else:
         wng_msg = "no nuclide provided"
         warnings.wrn(wng_msg, UserWarning)
-
     
-    selected_agents = agents.loc[lambda df: df.Prototype == facility, :]
-    if facility != 'All':
+    selected_agents = agents.loc[lambda df: df.Prototype == fac_name, :]
+    if fac_name != 'All':
         rdc_list.append(['AgentId', agents.ReceiverId])
     else:
         wng_msg = "no faciity provided"

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -6,7 +6,6 @@ import numpy as np
 import cymetric as cym
 import warnings
 
-
 def merge_n_drop(pdf, base_col, add_pdf, add_col):
     """
     Merge some additionnal columns fram an additionnal Pandas Data Frame
@@ -22,7 +21,6 @@ def merge_n_drop(pdf, base_col, add_pdf, add_col):
     pdf = pd.merge(add_pdf[add_col], pdf, on=base_col)
     pdf.drop(base_col[1], 1)
     return pdf
-
 
 def get_reduced_pdf(pdf, rdc_list):
     """
@@ -41,7 +39,6 @@ def get_reduced_pdf(pdf, rdc_list):
             warnings.wrn(wng_msg, UserWarning)
     return pdf
 
-
 def get_reduced__trans_pdf(db, send_name, rec_name):
     """
     Filter the Transaction Data Frame on specific sending facility and
@@ -52,9 +49,6 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
     db : database
     send_name : name of the sending facility ('All' for any)
     rec_name : name of the receiving facility ('All for any)
-
-    Attributes
-    ----------
     """
 
     # initiate evaluation
@@ -94,7 +88,6 @@ def get_reduced__trans_pdf(db, send_name, rec_name):
         trans = merge_n_drop(trans, base_col, rsc, added_col)
 
     return trans
-
 
 def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list=[]):
     """
@@ -148,7 +141,6 @@ def get_transaction_timeseries(db, send_name='All', rec_name='All', nuc_list=[])
         trans_table = grouped_trans.loc[rec_name].loc[send_name]
 
     return trans_table
-
 
 def get_inventory_timeseries(db, fac_name, nuc_list):
     """

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -2,119 +2,118 @@ from pyne import nucname
 import pandas as pd
 import numpy as np
 import cymetric as cym
+import warnings
 
-def GetTransactionTimeSeries(db, sender='All', receiver='All', *args):
+
+
+def select_agent(agent_name, agent, agent_type = "Agent"):
+    if agent_name != 'All':
+        agents_selected = agents.loc[
+            lambda df: df.Prototype == agent_name, :]
+        # check if exists
+        if agent_selected.empty:
+            wng_msg = "unknown " + agent_type + ", available Agents are:"
+            for receiver_name in agents.Prototype.unique():
+                wng_msg += " " + receiver_name
+            warnings.wrn(wng_msg, UserWarning)
+        else:
+            agents_pdf = agents_selected
+    return agents
+
+def merge_n_drop(pdf, base_col, add_pdf, add_col):
+    pdf = pd.merge(add_pdf[add_col], pdf, on = base_col);
+    pdf.drop(base_col[1],1)
+    return pdf
+
+
+def get_transaction_timeseries(db, send_name='All', rec_name='All'):
+
+
+    # initiate evaluation
+    evaler = cym.Evaluator(db)
+
+    # get transation & Agent tables
+    trans = evaler.eval('Transactions')
+    agents = evaler.eval('AgentEntry')
+    resources=evaler.eval('Resources')
+
+    # build 2 table for SenderId and ReceiverId
+    # get receiver
+    rec_list = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
+    rec_list = select_agent(receiver, rec_list, "Receiver")
+
+    # get sender
+    send_list = agents.rename(index=str, columns={'AgentId': 'SenderId'})
+    send_list = select_agent(send_name, send_list, "Sender")
     
+    # check if sender and receiver exist
+    if rec_list.empty or send_list.empty:
+        return None
+    else:
+    # Both receiver and sender exist:
+        trans = trans.loc[trans['ReceiverId'].isin(rec_list.ReceiveriId)]
+        trans = trans.loc[trans['SenderId'].isin(send_list.SenderId)]
+        resources=resources.loc[resource['ResourceId'].isin(trans.ResourceId)]
+
+        df = merge_n_drop(trans, ['SimId', 'SenderId'], send_list, ['SimId', 'SenderId', 'Prototype'])
+        df= df.rename(index = str, columns = {'Prototype': 'SenderProto'}) 
+
+        df = merge_n_drop(trans, ['SimId', 'ReceiverId'], rec_list, ['SimId', 'ReceiverId', 'Prototype'])
+        df= df.rename(index = str, columns = {'Prototype': 'ReceiverProto'}) 
+
+        df = merge_n_drop(trans, ['SimId', 'RessourceId'], resources, ['SimId', 'ResourceId', 'QualId', 'Quantity', 'Unit'])
+    
+    return df
+
+def get_transaction_timeseries(db, send_name='All', rec_name='All', *args):
+
+    df = get_transaction_timeseries(db, send_name, rec_name)
+        group_trans=df[['ReceiverProto', 'SenderProto', 'Time', 'Quantity']].groupby(
+            ['ReceiverProto', 'SenderProto', 'Time']).sum()
+
+        if sender == 'All':
+            grouped_trans=df[['ReceiverProto', 'Time', 'Quantity']].groupby(
+                ['ReceiverProto', 'Time']).sum()
+            trans_table=grouped_trans.loc[receiver]
+        elif receiver == 'All':
+            grouped_trans=df[['SenderProto', 'Time', 'Quantity']].groupby(
+                ['SenderProto', 'Time']).sum()
+            trans_table=grouped_trans.loc[sender]
+        else:
+            trans_table=grouped_trans.loc[receiver].loc[sender]
+
+    return trans_table
+
+
+def GetInventoryTimeSeries(db, facility, *args):
+
     nuc_list = []
     for inx, nuc in enumerate(args):
         nuc_list.append(nucname.id(nuc))
 
     # initiate evaluation
     evaler = cym.Evaluator(db)
-    
-    # get transation & Agent tables
-    trans = evaler.eval('Transactions')
-    agents = evaler.eval('AgentEntry')
-    
-# build 2 table for SenderId and ReceiverId
-    # get receiver
-    agents_receiver = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
-    if receiver != 'All':
-        agents_receiver_ = agents_receiver.loc[lambda df: df.Prototype == receiver,:]
-        # check if receiver exists
-        if agents_receiver_.empty:
-            print("unknown Receiver, available Receiver are:")
-            for receiver_name in agents_receiver.Prototype.unique(): # check if the loop is correct should it not be trans.XX.XX
-                print(receiver_name)
-        else:
-            agents_receiver = agents_receiver_
-    # get sender
-    agents_sender = agents.rename(index=str, columns={'AgentId': 'SenderId'})
-    if sender != 'All':
-        agents_sender_ = agents_sender.loc[lambda df: df.Prototype == sender,:]
-        # check if sender exists
-        if agents_sender_.empty:
-            print("unknown Sender, available Sender are:")
-            for sender_name in agents_sender.Prototype.unique():
-                print(sender_name)
-        else:
-            agents_sender = agents_sender_
 
-    # check if sender and receiver exist
-    if( agents_sender.empty or agents_receiver.empty):
-        return 0
-    else: 
-    # Both receiver and sender exist:
-        # select good corresponding transaction
-        selected_trans = trans.loc[trans['ReceiverId'].isin(agents_receiver.ReceiverId)]
-        selected_trans = selected_trans.loc[selected_trans['SenderId'].isin(agents_sender.SenderId)]
-        
-        # Merge Sender infos
-        df = pd.merge(agents_sender[['SimId', 'SenderId', 'Prototype']], selected_trans, on=['SimId', 'SenderId'])
-        df = df.rename(index=str, columns={'Prototype': 'SenderProto'})
-        df = df.drop('SenderId',1)
-        
-        # Merge reveiver infos
-        df = pd.merge(agents_receiver[['SimId', 'ReceiverId', 'Prototype']], df, on=['SimId', 'ReceiverId'])
-        df = df.rename(index=str, columns={'Prototype': 'ReceiverProto'})
-        df = df.drop('ReceiverId',1)
-
-        # Get resource and select the proper one
-        resource = evaler.eval('Resources')
-        selected_resources = resource.loc[resource['ResourceId'].isin(selected_trans.ResourceId)]
-
-        # merge Resource into transaction
-        df = pd.merge(selected_resources[['SimId', 'ResourceId','QualId','Quantity','Units'    ]], df, on=['SimId', 'ResourceId'])
-        df = df.drop('ResourceId',1)
-
-        if len(nuc_list) != 0: # Nuclide required -> do the Math
-            compo = evaler.eval('Compositions')
-            selected_compo = compo.loc[compo['NucId'].isin(nuc_list)]
-
-            df = pd.merge(selected_compo[['SimId', 'QualId','NucId','MassFrac'    ]], df, on=['SimId', 'QualId'])
-            df['Quantity'] = df['Quantity'] * df['MassFrac']
-        
-        grouped_trans = df[['ReceiverProto', 'SenderProto','Time', 'Quantity']].groupby(['ReceiverProto', 'SenderProto','Time']).sum()
-
-        if sender == 'All':
-            grouped_trans = df[['ReceiverProto','Time', 'Quantity']].groupby(['ReceiverProto','Time']).sum()
-            trans_table = grouped_trans.loc[receiver]
-        elif receiver == 'All':
-            grouped_trans = df[['SenderProto','Time', 'Quantity']].groupby(['SenderProto','Time']).sum()
-            trans_table = grouped_trans.loc[sender]
-        else:
-            trans_table = grouped_trans.loc[receiver].loc[sender]
-    
-    return trans_table
-
-
-def GetInventoryTimeSeries(db, facility, *args):
-    
-    nuc_list = []
-    for inx, nuc in enumerate(args):
-        nuc_list.append(nucname.id(nuc))
-    
-    #initiate evaluation
-    evaler = cym.Evaluator(db)
-    
     # Get inventory table
     inv = evaler.eval('ExplicitInventory')
-    if len(nuc_list) != 0 :
+    if len(nuc_list) != 0:
         inv = inv.loc[inv['NucId'].isin(nuc_list)]
     agents = evaler.eval('AgentEntry')
 
-    selected_agents = agents.loc[lambda df: df.Prototype == facility,:]
+    selected_agents = agents.loc[lambda df: df.Prototype == facility, :]
     if selected_agents.empty:
         print("unknown Facitlity, available Facilities are:")
         for fac_name in agents.Prototype.unique():
             print(fac_name)
-        inv_table = 0
+        inv_table = None
     else:
         selected_inv = inv.loc[inv['AgentId'].isin(selected_agents.AgentId)]
-        
-        df = pd.merge(selected_agents[['SimId', 'AgentId', 'Prototype']], selected_inv, on=['SimId', 'AgentId'])
-        df = df.drop('AgentId',1)
-        
-        inv_table = df[['Prototype', 'Time','Quantity']].groupby(['Prototype', 'Time']).sum()
+
+        df = pd.merge(selected_agents[
+                      ['SimId', 'AgentId', 'Prototype']], selected_inv, on=['SimId', 'AgentId'])
+        df = df.drop('AgentId', 1)
+
+        inv_table = df[['Prototype', 'Time', 'Quantity']
+                       ].groupby(['Prototype', 'Time']).sum()
 
     return inv_table

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -3,14 +3,13 @@ import pandas as pd
 import numpy as np
 import cymetric as cym
 
-def GetTransactionTimeSeries(db, sender='All', receiver='All', *xargs):
-
+def GetTransactionTimeSeries(db, sender='All', receiver='All', *args):
   
   nuc_list = []
-  for inx, nuc in enumerate(xargs):
+  for inx, nuc in enumerate(args):
     nuc_list.append(nucname.id(nuc))
 
-  #initiate evaluation
+  # initiate evaluation
   evaler = cym.Evaluator(db)
   
   # get transation & Agent tables
@@ -25,7 +24,7 @@ def GetTransactionTimeSeries(db, sender='All', receiver='All', *xargs):
     # check if receiver exists
     if agents_receiver_.empty:
       print("unknown Receiver, available Receiver are:")
-      for receiver_name in agents_receiver.Prototype.unique(): #check if the loop is correct should it not be trans.XX.XX
+      for receiver_name in agents_receiver.Prototype.unique(): # check if the loop is correct should it not be trans.XX.XX
         print(receiver_name)
     else:
       agents_receiver = agents_receiver_
@@ -89,10 +88,10 @@ def GetTransactionTimeSeries(db, sender='All', receiver='All', *xargs):
   return trans_table
 
 
-def GetInventoryTimeSeries(db, facility, *xargs):
+def GetInventoryTimeSeries(db, facility, *args):
   
   nuc_list = []
-  for inx, nuc in enumerate(xargs):
+  for inx, nuc in enumerate(args):
     nuc_list.append(nucname.id(nuc))
   
   #initiate evaluation

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -4,117 +4,117 @@ import numpy as np
 import cymetric as cym
 
 def GetTransactionTimeSeries(db, sender='All', receiver='All', *args):
-  
-  nuc_list = []
-  for inx, nuc in enumerate(args):
-    nuc_list.append(nucname.id(nuc))
+    
+    nuc_list = []
+    for inx, nuc in enumerate(args):
+        nuc_list.append(nucname.id(nuc))
 
-  # initiate evaluation
-  evaler = cym.Evaluator(db)
-  
-  # get transation & Agent tables
-  trans = evaler.eval('Transactions')
-  agents = evaler.eval('AgentEntry')
-  
+    # initiate evaluation
+    evaler = cym.Evaluator(db)
+    
+    # get transation & Agent tables
+    trans = evaler.eval('Transactions')
+    agents = evaler.eval('AgentEntry')
+    
 # build 2 table for SenderId and ReceiverId
-  # get receiver
-  agents_receiver = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
-  if receiver != 'All':
-    agents_receiver_ = agents_receiver.loc[lambda df: df.Prototype == receiver,:]
-    # check if receiver exists
-    if agents_receiver_.empty:
-      print("unknown Receiver, available Receiver are:")
-      for receiver_name in agents_receiver.Prototype.unique(): # check if the loop is correct should it not be trans.XX.XX
-        print(receiver_name)
-    else:
-      agents_receiver = agents_receiver_
-  # get sender
-  agents_sender = agents.rename(index=str, columns={'AgentId': 'SenderId'})
-  if sender != 'All':
-    agents_sender_ = agents_sender.loc[lambda df: df.Prototype == sender,:]
-    # check if sender exists
-    if agents_sender_.empty:
-      print("unknown Sender, available Sender are:")
-      for sender_name in agents_sender.Prototype.unique():
-        print(sender_name)
-    else:
-      agents_sender = agents_sender_
+    # get receiver
+    agents_receiver = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
+    if receiver != 'All':
+        agents_receiver_ = agents_receiver.loc[lambda df: df.Prototype == receiver,:]
+        # check if receiver exists
+        if agents_receiver_.empty:
+            print("unknown Receiver, available Receiver are:")
+            for receiver_name in agents_receiver.Prototype.unique(): # check if the loop is correct should it not be trans.XX.XX
+                print(receiver_name)
+        else:
+            agents_receiver = agents_receiver_
+    # get sender
+    agents_sender = agents.rename(index=str, columns={'AgentId': 'SenderId'})
+    if sender != 'All':
+        agents_sender_ = agents_sender.loc[lambda df: df.Prototype == sender,:]
+        # check if sender exists
+        if agents_sender_.empty:
+            print("unknown Sender, available Sender are:")
+            for sender_name in agents_sender.Prototype.unique():
+                print(sender_name)
+        else:
+            agents_sender = agents_sender_
 
-  # check if sender and receiver exist
-  if( agents_sender.empty or agents_receiver.empty):
-    return 0
-  else: 
-  # Both receiver and sender exist:
-    # select good corresponding transaction
-    selected_trans = trans.loc[trans['ReceiverId'].isin(agents_receiver.ReceiverId)]
-    selected_trans = selected_trans.loc[selected_trans['SenderId'].isin(agents_sender.SenderId)]
+    # check if sender and receiver exist
+    if( agents_sender.empty or agents_receiver.empty):
+        return 0
+    else: 
+    # Both receiver and sender exist:
+        # select good corresponding transaction
+        selected_trans = trans.loc[trans['ReceiverId'].isin(agents_receiver.ReceiverId)]
+        selected_trans = selected_trans.loc[selected_trans['SenderId'].isin(agents_sender.SenderId)]
+        
+        # Merge Sender infos
+        df = pd.merge(agents_sender[['SimId', 'SenderId', 'Prototype']], selected_trans, on=['SimId', 'SenderId'])
+        df = df.rename(index=str, columns={'Prototype': 'SenderProto'})
+        df = df.drop('SenderId',1)
+        
+        # Merge reveiver infos
+        df = pd.merge(agents_receiver[['SimId', 'ReceiverId', 'Prototype']], df, on=['SimId', 'ReceiverId'])
+        df = df.rename(index=str, columns={'Prototype': 'ReceiverProto'})
+        df = df.drop('ReceiverId',1)
+
+        # Get resource and select the proper one
+        resource = evaler.eval('Resources')
+        selected_resources = resource.loc[resource['ResourceId'].isin(selected_trans.ResourceId)]
+
+        # merge Resource into transaction
+        df = pd.merge(selected_resources[['SimId', 'ResourceId','QualId','Quantity','Units'    ]], df, on=['SimId', 'ResourceId'])
+        df = df.drop('ResourceId',1)
+
+        if len(nuc_list) != 0: # Nuclide required -> do the Math
+            compo = evaler.eval('Compositions')
+            selected_compo = compo.loc[compo['NucId'].isin(nuc_list)]
+
+            df = pd.merge(selected_compo[['SimId', 'QualId','NucId','MassFrac'    ]], df, on=['SimId', 'QualId'])
+            df['Quantity'] = df['Quantity'] * df['MassFrac']
+        
+        grouped_trans = df[['ReceiverProto', 'SenderProto','Time', 'Quantity']].groupby(['ReceiverProto', 'SenderProto','Time']).sum()
+
+        if sender == 'All':
+            grouped_trans = df[['ReceiverProto','Time', 'Quantity']].groupby(['ReceiverProto','Time']).sum()
+            trans_table = grouped_trans.loc[receiver]
+        elif receiver == 'All':
+            grouped_trans = df[['SenderProto','Time', 'Quantity']].groupby(['SenderProto','Time']).sum()
+            trans_table = grouped_trans.loc[sender]
+        else:
+            trans_table = grouped_trans.loc[receiver].loc[sender]
     
-    # Merge Sender infos
-    df = pd.merge(agents_sender[['SimId', 'SenderId', 'Prototype']], selected_trans, on=['SimId', 'SenderId'])
-    df = df.rename(index=str, columns={'Prototype': 'SenderProto'})
-    df = df.drop('SenderId',1)
-    
-    # Merge reveiver infos
-    df = pd.merge(agents_receiver[['SimId', 'ReceiverId', 'Prototype']], df, on=['SimId', 'ReceiverId'])
-    df = df.rename(index=str, columns={'Prototype': 'ReceiverProto'})
-    df = df.drop('ReceiverId',1)
-
-    # Get resource and select the proper one
-    resource = evaler.eval('Resources')
-    selected_resources = resource.loc[resource['ResourceId'].isin(selected_trans.ResourceId)]
-
-    # merge Resource into transaction
-    df = pd.merge(selected_resources[['SimId', 'ResourceId','QualId','Quantity','Units'  ]], df, on=['SimId', 'ResourceId'])
-    df = df.drop('ResourceId',1)
-
-    if len(nuc_list) != 0: # Nuclide required -> do the Math
-      compo = evaler.eval('Compositions')
-      selected_compo = compo.loc[compo['NucId'].isin(nuc_list)]
-
-      df = pd.merge(selected_compo[['SimId', 'QualId','NucId','MassFrac'  ]], df, on=['SimId', 'QualId'])
-      df['Quantity'] = df['Quantity'] * df['MassFrac']
-    
-    grouped_trans = df[['ReceiverProto', 'SenderProto','Time', 'Quantity']].groupby(['ReceiverProto', 'SenderProto','Time']).sum()
-
-    if sender == 'All':
-      grouped_trans = df[['ReceiverProto','Time', 'Quantity']].groupby(['ReceiverProto','Time']).sum()
-      trans_table = grouped_trans.loc[receiver]
-    elif receiver == 'All':
-      grouped_trans = df[['SenderProto','Time', 'Quantity']].groupby(['SenderProto','Time']).sum()
-      trans_table = grouped_trans.loc[sender]
-    else:
-      trans_table = grouped_trans.loc[receiver].loc[sender]
-  
-  return trans_table
+    return trans_table
 
 
 def GetInventoryTimeSeries(db, facility, *args):
-  
-  nuc_list = []
-  for inx, nuc in enumerate(args):
-    nuc_list.append(nucname.id(nuc))
-  
-  #initiate evaluation
-  evaler = cym.Evaluator(db)
-  
-  # Get inventory table
-  inv = evaler.eval('ExplicitInventory')
-  if len(nuc_list) != 0 :
-    inv = inv.loc[inv['NucId'].isin(nuc_list)]
-  agents = evaler.eval('AgentEntry')
-
-  selected_agents = agents.loc[lambda df: df.Prototype == facility,:]
-  if selected_agents.empty:
-    print("unknown Facitlity, available Facilities are:")
-    for fac_name in agents.Prototype.unique():
-      print(fac_name)
-    inv_table = 0
-  else:
-    selected_inv = inv.loc[inv['AgentId'].isin(selected_agents.AgentId)]
     
-    df = pd.merge(selected_agents[['SimId', 'AgentId', 'Prototype']], selected_inv, on=['SimId', 'AgentId'])
-    df = df.drop('AgentId',1)
+    nuc_list = []
+    for inx, nuc in enumerate(args):
+        nuc_list.append(nucname.id(nuc))
     
-    inv_table = df[['Prototype', 'Time','Quantity']].groupby(['Prototype', 'Time']).sum()
+    #initiate evaluation
+    evaler = cym.Evaluator(db)
+    
+    # Get inventory table
+    inv = evaler.eval('ExplicitInventory')
+    if len(nuc_list) != 0 :
+        inv = inv.loc[inv['NucId'].isin(nuc_list)]
+    agents = evaler.eval('AgentEntry')
 
-  return inv_table
+    selected_agents = agents.loc[lambda df: df.Prototype == facility,:]
+    if selected_agents.empty:
+        print("unknown Facitlity, available Facilities are:")
+        for fac_name in agents.Prototype.unique():
+            print(fac_name)
+        inv_table = 0
+    else:
+        selected_inv = inv.loc[inv['AgentId'].isin(selected_agents.AgentId)]
+        
+        df = pd.merge(selected_agents[['SimId', 'AgentId', 'Prototype']], selected_inv, on=['SimId', 'AgentId'])
+        df = df.drop('AgentId',1)
+        
+        inv_table = df[['Prototype', 'Time','Quantity']].groupby(['Prototype', 'Time']).sum()
+
+    return inv_table

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -5,9 +5,6 @@ import cymetric as cym
 
 def GetTransactionTimeSeries(db, sender='All', receiver='All', *xargs):
 
-  if sender == 'All' and receiver == 'All':
-    print( " Please choose a Receiver or a Sender or both!!")
-    return 0
   
   nuc_list = []
   for inx, nuc in enumerate(xargs):

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -131,7 +131,9 @@ def get_transaction_df(evaler_, send_list=[], rec_list=[], commod_list=[]):
 
 def get_transaction_nuc_df(evaler_, send_list=[], rec_list=[], commod_list=[], nuc_list=[]):
     """
-    Shape the reduced transation Data Frame into a simple time serie. Applying nuclides selection when required.
+
+    Filter the Transaction Data Frame, which include nuclide composition, on specific sending facility and
+    receving facility. Applying nuclides selection when required.
 
     Parameters
     ----------

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -3,9 +3,9 @@ import pandas as pd
 import numpy as np
 import cymetric as cym
 
-def GetTransactionTimeSeries(db, sender='None', receiver='None', *xargs):
+def GetTransactionTimeSeries(db, sender='All', receiver='All', *xargs):
 
-  if sender == 'None' and receiver == 'None':
+  if sender == 'All' and receiver == 'All':
     print( " Please choose a Receiver or a Sender or both!!")
     return 0
   
@@ -21,9 +21,9 @@ def GetTransactionTimeSeries(db, sender='None', receiver='None', *xargs):
   agents = evaler.eval('AgentEntry')
   
 # build 2 table for SenderId and ReceiverId
-  # get receiveri
+  # get receiver
   agents_receiver = agents.rename(index=str, columns={'AgentId': 'ReceiverId'})
-  if receiver != 'None':
+  if receiver != 'All':
     agents_receiver_ = agents_receiver.loc[lambda df: df.Prototype == receiver,:]
     # check if receiver exists
     if agents_receiver_.empty:
@@ -32,11 +32,9 @@ def GetTransactionTimeSeries(db, sender='None', receiver='None', *xargs):
         print(receiver_name)
     else:
       agents_receiver = agents_receiver_
-
-
   # get sender
   agents_sender = agents.rename(index=str, columns={'AgentId': 'SenderId'})
-  if sender != 'None':
+  if sender != 'All':
     agents_sender_ = agents_sender.loc[lambda df: df.Prototype == sender,:]
     # check if sender exists
     if agents_sender_.empty:
@@ -46,7 +44,7 @@ def GetTransactionTimeSeries(db, sender='None', receiver='None', *xargs):
     else:
       agents_sender = agents_sender_
 
-  #check if seider and receiver exist
+  # check if sender and receiver exist
   if( agents_sender.empty or agents_receiver.empty):
     return 0
   else: 
@@ -82,10 +80,10 @@ def GetTransactionTimeSeries(db, sender='None', receiver='None', *xargs):
     
     grouped_trans = df[['ReceiverProto', 'SenderProto','Time', 'Quantity']].groupby(['ReceiverProto', 'SenderProto','Time']).sum()
 
-    if sender == 'None':
+    if sender == 'All':
       grouped_trans = df[['ReceiverProto','Time', 'Quantity']].groupby(['ReceiverProto','Time']).sum()
       trans_table = grouped_trans.loc[receiver]
-    elif receiver == 'None':
+    elif receiver == 'All':
       grouped_trans = df[['SenderProto','Time', 'Quantity']].groupby(['SenderProto','Time']).sum()
       trans_table = grouped_trans.loc[sender]
     else:

--- a/cymetric/convenient_interface.py
+++ b/cymetric/convenient_interface.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import cymetric as cym
 
-def GetTransactionTimeSerie(db, sender='None', receiver='None', *xargs):
+def GetTransactionTimeSeries(db, sender='None', receiver='None', *xargs):
 
   if sender == 'None' and receiver == 'None':
     print( " Please choose a Receiver or a Sender or both!!")
@@ -94,7 +94,7 @@ def GetTransactionTimeSerie(db, sender='None', receiver='None', *xargs):
   return trans_table
 
 
-def GetInventoryTimeSerie(db, facility, *xargs):
+def GetInventoryTimeSeries(db, facility, *xargs):
   
   nuc_list = []
   for inx, nuc in enumerate(xargs):

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -231,7 +231,7 @@ def decommission_series(series):
     agent_exit = series[1]
     exit_index = ['SimId', 'ExitTime', 'Prototype']
     if agent_exit is not None:
-    	exit = pd.merge(agent_entry.reset_index(), agent_exit.reset_index(),
+        exit = pd.merge(agent_entry.reset_index(), agent_exit.reset_index(),
             on=['SimId', 'AgentId'], how='inner').set_index(exit_index)
     else:
         return print('No agents were decommissioned during this simulation.')
@@ -402,7 +402,7 @@ def annual_electricity_generated_by_agent(series):
                               'AgentId': elec.AgentId,
                               'Year': elec.Time.apply(lambda x: x//12),
                               'Energy': elec.Value.apply(lambda x: x/12)},
-			columns=['SimId', 'AgentId', 'Year', 'Energy'])
+                        columns=['SimId', 'AgentId', 'Year', 'Energy'])
     el_index = ['SimId', 'AgentId', 'Year']
     elec = elec.groupby(el_index).sum()
     rtn = elec.reset_index()

--- a/cymetric/metrics.py
+++ b/cymetric/metrics.py
@@ -297,7 +297,7 @@ del _agentsdeps, _agentsschema
 
 # Transaction Quantity
 _transdeps = [
-    ('Materials', ('SimId', 'ResourceId', 'ObjId', 'TimeCreated', 'Units'),
+    ('Materials', ('SimId', 'QualId', 'ResourceId', 'ObjId', 'TimeCreated', 'NucId'),
         'Mass'),
     ('Transactions', ('SimId', 'TransactionId', 'SenderId', 'ReceiverId',
         'ResourceId'), 'Commodity')

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -231,7 +231,7 @@ def test_convint_gettransactioninucdf(db, fname, backend):
 
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
-    # test single nuclide sectection
+    # test single nuclide selection
     cal = com.get_transaction_nuc_df(myEval, nuc_list=['942390000'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
@@ -247,6 +247,40 @@ def test_convint_gettransactioninucdf(db, fname, backend):
         (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
         (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 0.0444814879803, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    #refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+    
+    
+    # test multiple nuclide selection
+    cal = com.get_transaction_nuc_df(myEval, nuc_list=['942390000', '922380000'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (922380000, 0.7872433760310, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (922380000, 0.7872433760310, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (922380000, 0.7872433760310, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (922380000, 0.7872433760310, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (922380000, 0.7872433760310, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (922380000, 0.7872433760310, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (922380000, 0.7872433760310, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 0.0444814879803, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+        (922380000, 0.9600000000000, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (922380000, 0.9600000000000, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
         ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
         ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -26,9 +26,8 @@ def test_convint_gettransactiondf(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_df(myEval)
 
-    exp_head = ['SimId', 'ReceiverId', 'ReceiverProto',
-                'SenderId', 'SenderProto', 'TransactionId',
-                'ResourceId', 'Commodity', 'Time']
+    exp_head = ['SimId', 'ReceiverId', 'ReceiverProto', 'SenderId',
+                'SenderProto', 'TransactionId', 'ResourceId', 'Commodity', 'Time']
 
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
@@ -220,6 +219,40 @@ def test_convint_gettransactiondf(db, fname, backend):
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
+
+@dbtest
+def test_convint_gettransactioninucdf(db, fname, backend):
+    #db = cym.dbopen()
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_nuc_df(myEval)
+
+    exp_head = ['SimId', 'ResourceId', 'NucId', 'Mass', 'ReceiverId', 'ReceiverProto',
+                'SenderId', 'SenderProto', 'TransactionId', 'ResourceId', 'Commodity', 'Time']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+#    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+#    # SimId change at each test need to drop it
+#    cal = cal.drop('TransactionId', 1)
+#    # SimId change at each test need to drop it
+#    cal = cal.drop('ResourceId', 1)
+#
+#    refs = pd.DataFrame(np.array([
+#        (942390000, 0.044481, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+#        (942390000, 0.044481, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+#        (942390000, 0.044481, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+#        (942390000, 0.044481, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+#        (942390000, 0.044481, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+#        (942390000, 0.044481, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+#        (942390000, 0.044481, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+#    ], dtype=ensure_dt_bytes([
+#        ('NucId', '<i8'), ('Mass', '<i8'), ('ReceiverId',
+#                                            '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+#        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+#    ]))
+#    )
+#    refs.index = refs.index.astype('str')
+#    assert_frame_equal(cal, refs)
 
 if __name__ == "__main__":
     nose.runmodule()

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -565,15 +565,15 @@ def test_convint_get_inventory_df(db, fname, backend):
     print(cal)
 
     refs = pd.DataFrame(np.array([
-        (0, 15, 'Reactor1', 1, 'core', 942390000, 0.044481),
-        (1, 15, 'Reactor1', 2, 'core', 942390000, 0.044481),
-        (2, 15, 'Reactor1', 2, 'spent', 942390000, 0.017699),
-        (3, 15, 'Reactor1', 3, 'core', 942390000, 0.044481),
-        (4, 15, 'Reactor1', 3, 'spent', 942390000, 0.035398),
-        (5, 15, 'Reactor1', 4, 'spent', 942390000, 0.053097)
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442),
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327)
     ], dtype=ensure_dt_bytes([
-        ('AgentId', '<i8'), ('Prototype', '0'), ('Time', '<i8'),
-        ('InventoryName', 'O'), ('NucIdId', '<i8'), ('Quantity', '<f8')
+        ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')
     ]))
     )
     assert_frame_equal(cal, refs)

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -227,32 +227,33 @@ def test_convint_gettransactioninucdf(db, fname, backend):
     cal = com.get_transaction_nuc_df(myEval)
 
     exp_head = ['SimId', 'ResourceId', 'NucId', 'Mass', 'ReceiverId', 'ReceiverProto',
-                'SenderId', 'SenderProto', 'TransactionId', 'ResourceId', 'Commodity', 'Time']
+                'SenderId', 'SenderProto', 'TransactionId', 'Commodity', 'Time']
 
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
-#    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
-#    # SimId change at each test need to drop it
-#    cal = cal.drop('TransactionId', 1)
-#    # SimId change at each test need to drop it
-#    cal = cal.drop('ResourceId', 1)
-#
-#    refs = pd.DataFrame(np.array([
-#        (942390000, 0.044481, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
-#        (942390000, 0.044481, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
-#        (942390000, 0.044481, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
-#        (942390000, 0.044481, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
-#        (942390000, 0.044481, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
-#        (942390000, 0.044481, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
-#        (942390000, 0.044481, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
-#    ], dtype=ensure_dt_bytes([
-#        ('NucId', '<i8'), ('Mass', '<i8'), ('ReceiverId',
-#                                            '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
-#        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-#    ]))
-#    )
-#    refs.index = refs.index.astype('str')
-#    assert_frame_equal(cal, refs)
+    # test single nuclide sectection
+    cal = com.get_transaction_nuc_df(myEval, nuc_list=['942390000'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 0.0444814879803, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    #refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
 
 if __name__ == "__main__":
     nose.runmodule()

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -19,8 +19,9 @@ import cymetric as cym
 from cymetric import convenient_interface as com
 from cymetric.tools import raw_to_series, ensure_dt_bytes
 
+
 @dbtest
-def test_convint_gettransactiondf(db,fname,backend):
+def test_convint_gettransactiondf(db, fname, backend):
     #db = cym.dbopen()
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_df(myEval)
@@ -29,11 +30,13 @@ def test_convint_gettransactiondf(db,fname,backend):
                 'SenderId', 'SenderProto', 'TransactionId',
                 'ResourceId', 'Commodity', 'Time']
 
-    assert_equal(list(cal), exp_head) # CHeck we have the correct headers
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
-    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
 
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
@@ -45,40 +48,43 @@ def test_convint_gettransactiondf(db,fname,backend):
         (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
-    ], dtype = ensure_dt_bytes([
+    ], dtype=ensure_dt_bytes([
         ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
         ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-        ]))
+    ]))
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
-    
-    
+
     # test single sender
-    cal = com.get_transaction_df(myEval,send_list=['UOX_Source'])
+    cal = com.get_transaction_df(myEval, send_list=['UOX_Source'])
 
-    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
 
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
-    ], dtype = ensure_dt_bytes([
+    ], dtype=ensure_dt_bytes([
         ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
         ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-        ]))
+    ]))
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
-    
     # test multiple sender
-    cal = com.get_transaction_df(myEval,send_list=['UOX_Source', 'MOX_Source'])
-    
-    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+    cal = com.get_transaction_df(
+        myEval, send_list=['UOX_Source', 'MOX_Source'])
+
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
 
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
@@ -90,41 +96,43 @@ def test_convint_gettransactiondf(db,fname,backend):
         (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
-    ], dtype = ensure_dt_bytes([
+    ], dtype=ensure_dt_bytes([
         ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
         ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-        ]))
+    ]))
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
-    
     # test single receiver
     cal = com.get_transaction_df(myEval, rec_list=['Reactor1'])
-    
-    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
 
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
-    ], dtype = ensure_dt_bytes([
+    ], dtype=ensure_dt_bytes([
         ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
         ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-        ]))
+    ]))
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
-    
     # test multiple sender
     cal = com.get_transaction_df(myEval, rec_list=['Reactor1', 'Reactor3'])
-    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
 
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
@@ -133,21 +141,23 @@ def test_convint_gettransactiondf(db,fname,backend):
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
         (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
-    ], dtype = ensure_dt_bytes([
+    ], dtype=ensure_dt_bytes([
         ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
         ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-        ]))
+    ]))
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
 
 # test multiple sender and multiple receiver
-    cal = com.get_transaction_df(myEval,send_list=['UOX_Source', 'MOX_Source'],
-            rec_list=['Reactor1', 'Reactor2'])
-    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+    cal = com.get_transaction_df(myEval, send_list=['UOX_Source', 'MOX_Source'],
+                                 rec_list=['Reactor1', 'Reactor2'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
 
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
@@ -157,10 +167,55 @@ def test_convint_gettransactiondf(db,fname,backend):
         (16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
         (16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
         (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
-    ], dtype = ensure_dt_bytes([
+    ], dtype=ensure_dt_bytes([
         ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
         ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
-        ]))
+    ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+    # test single commodity
+    cal = com.get_transaction_df(myEval, commod_list=['uox'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+    ], dtype=ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+    # test multiple sender
+    cal = com.get_transaction_df(myEval, commod_list=['uox', 'mox'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
@@ -170,21 +225,12 @@ if __name__ == "__main__":
     nose.runmodule()
 
 
-
-
-
-
-
-
-
-
-
 #[left]:  [6, 0, 2, 5, 1, 4, 8, 3, 7]
 #[left]:  [6, 0, 1, 4, 2, 5, 7, 3, 8]
 #[right]: [6, 0, 2, 5, 1, 4, 8, 3, 7]
 
 #@dbtest
-#def test_resources(db, fname, backend):
+# def test_resources(db, fname, backend):
 #    r = root_metrics.resources(db=db)
 #    obs = r()
 #    assert_less(0, len(obs))

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -454,7 +454,6 @@ def test_convint_get_transaction_timeserie(db, fname, backend):
     # test multiple nuclide selection
     cal = com.get_transaction_timeseries(
         myEval, nuc_list=['942390000', '922380000'])
-    print(cal)
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
         (1, 0.831724864011),
@@ -463,6 +462,47 @@ def test_convint_get_transaction_timeserie(db, fname, backend):
         (4, 2.62344972802),
     ], dtype=ensure_dt_bytes([
         ('Time', '<i8'), ('Mass', '<f8')
+    ]))
+    )
+
+    assert_frame_equal(cal, refs)
+
+
+@dbtest
+def test_convint_get_transaction_activity_timeserie(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_activity_timeseries(myEval)
+
+    exp_head = ['Time', 'Activity']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    # test single nuclide selection
+    cal = com.get_transaction_activity_timeseries(
+        myEval, nuc_list=['942390000'])
+    refs = pd.DataFrame(np.array([
+        (0, 0.000000000),
+        (1, 102084984531.0),
+        (2, 204169969062.0),
+        (3, 204169969062.0),
+        (4, 204169969062.0),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Activity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+    # test multiple nuclide selection
+    cal = com.get_transaction_activity_timeseries(
+        myEval, nuc_list=['942390000', '922380000'])
+    refs = pd.DataFrame(np.array([
+        (0, 0.000000000),
+        (1, 102094774891.0),
+        (2, 204189549782.0),
+        (3, 204201488588.0),
+        (4, 204201488588.0),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Activity', '<f8')
     ]))
     )
 

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -549,5 +549,35 @@ def test_convint_get_transaction_decayheat_timeserie(db, fname, backend):
     assert_frame_equal(cal, refs)
 
 
+@dbtest
+def test_convint_get_inventory_df(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_inventory_df(myEval)
+
+    exp_head = ['SimId', 'AgentId', 'Prototype',
+                'Time', 'InventoryName', 'NucId', 'Quantity']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    cal = com.get_inventory_df(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    print(cal)
+
+    refs = pd.DataFrame(np.array([
+        (0, 15, 'Reactor1', 1, 'core', 942390000, 0.044481),
+        (1, 15, 'Reactor1', 2, 'core', 942390000, 0.044481),
+        (2, 15, 'Reactor1', 2, 'spent', 942390000, 0.017699),
+        (3, 15, 'Reactor1', 3, 'core', 942390000, 0.044481),
+        (4, 15, 'Reactor1', 3, 'spent', 942390000, 0.035398),
+        (5, 15, 'Reactor1', 4, 'spent', 942390000, 0.053097)
+    ], dtype=ensure_dt_bytes([
+        ('AgentId', '<i8'), ('Prototype', '0'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucIdId', '<i8'), ('Quantity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+
 if __name__ == "__main__":
     nose.runmodule()

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -508,6 +508,46 @@ def test_convint_get_transaction_activity_timeserie(db, fname, backend):
 
     assert_frame_equal(cal, refs)
 
+@dbtest
+def test_convint_get_transaction_decayheat_timeserie(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_decayheat_timeseries(myEval)
+
+    exp_head = ['Time', 'DecayHeat']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    # test single nuclide selection
+    cal = com.get_transaction_decayheat_timeseries(
+        myEval, nuc_list=['942390000'])
+    refs = pd.DataFrame(np.array([
+        (0, 0.000000000),
+        (1, 3.34065303191e+30),
+        (2, 6.68130606382e+30),
+        (3, 6.68130606382e+30),
+        (4, 6.68130606382e+30),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('DecayHeat', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+    # test multiple nuclide selection
+    cal = com.get_transaction_decayheat_timeseries(
+        myEval, nuc_list=['942390000', '922380000'])
+    refs = pd.DataFrame(np.array([
+        (0, 0.000000000),
+        (1, 3.34091395721e+30),
+        (2, 6.68182791443e+30),
+        (3, 6.68214609848e+30),
+        (4, 6.68214609848e+30),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('DecayHeat', '<f8')
+    ]))
+    )
+
+    assert_frame_equal(cal, refs)
+
 
 if __name__ == "__main__":
     nose.runmodule()

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -52,6 +52,131 @@ def test_convint_gettransactiondf(db,fname,backend):
     )
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
+    
+    
+    # test single sender
+    cal = com.get_transaction_df(myEval,send_list=['UOX_Source'])
+
+    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+    ], dtype = ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+    
+    # test multiple sender
+    cal = com.get_transaction_df(myEval,send_list=['UOX_Source', 'MOX_Source'])
+    
+    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype = ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+    
+    # test single receiver
+    cal = com.get_transaction_df(myEval, rec_list=['Reactor1'])
+    
+    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+    ], dtype = ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+    
+    # test multiple sender
+    cal = com.get_transaction_df(myEval, rec_list=['Reactor1', 'Reactor3'])
+    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype = ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+
+# test multiple sender and multiple receiver
+    cal = com.get_transaction_df(myEval,send_list=['UOX_Source', 'MOX_Source'],
+            rec_list=['Reactor1', 'Reactor2'])
+    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+    ], dtype = ensure_dt_bytes([
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ]))
+    )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+
+if __name__ == "__main__":
+    nose.runmodule()
+
+
+
+
+
+
+
+
+
 
 
 #[left]:  [6, 0, 2, 5, 1, 4, 8, 3, 7]
@@ -64,7 +189,3 @@ def test_convint_gettransactiondf(db,fname,backend):
 #    obs = r()
 #    assert_less(0, len(obs))
 #    assert_equal('Resources', r.name)
-
-
-if __name__ == "__main__":
-    nose.runmodule()

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -24,17 +24,17 @@ def test_convint_gettransactiondf(db,fname,backend):
     #db = cym.dbopen()
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_df(myEval)
-    
+
     exp_head = ['SimId', 'ReceiverId', 'ReceiverProto',
                 'SenderId', 'SenderProto', 'TransactionId',
                 'ResourceId', 'Commodity', 'Time']
 
-    assert_equal(list(cal), exp_head)
+    assert_equal(list(cal), exp_head) # CHeck we have the correct headers
 
-    cal = cal.drop('SimId', 1) #SimId change at each test need to drop it
-    cal = cal.drop('TransactionId', 1) #SimId change at each test need to drop it
-    cal = cal.drop('ResourceId', 1) #SimId change at each test need to drop it
-    
+    cal = cal.drop('SimId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) # SimId change at each test need to drop it
+
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -21,8 +21,7 @@ from cymetric.tools import raw_to_series, ensure_dt_bytes
 
 
 @dbtest
-def test_convint_gettransactiondf(db, fname, backend):
-    #db = cym.dbopen()
+def test_convint_get_transaction_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_df(myEval)
 
@@ -221,8 +220,7 @@ def test_convint_gettransactiondf(db, fname, backend):
 
 
 @dbtest
-def test_convint_gettransactioninucdf(db, fname, backend):
-    #db = cym.dbopen()
+def test_convint_get_transaction_nuc_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_nuc_df(myEval)
 
@@ -254,8 +252,7 @@ def test_convint_gettransactioninucdf(db, fname, backend):
     )
     #refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
-    
-    
+
     # test multiple nuclide selection
     cal = com.get_transaction_nuc_df(myEval, nuc_list=['942390000', '922380000'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
@@ -289,6 +286,73 @@ def test_convint_gettransactioninucdf(db, fname, backend):
     #refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
+
+@dbtest
+def test_convint_get_transaction_activity_df(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_activity_df(myEval)
+
+    exp_head = ['SimId', 'ResourceId', 'NucId', 'Activity', 'ReceiverId', 'ReceiverProto',
+                'SenderId', 'SenderProto', 'TransactionId', 'Commodity', 'Time']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    # test single nuclide selection
+    cal = com.get_transaction_activity_df(myEval, nuc_list=['942390000'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 102084984531.0, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    #refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+    # test multiple nuclide selection
+    cal = com.get_transaction_activity_df(myEval, nuc_list=['942390000', '922380000'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (922380000, 9790360.331530, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (922380000, 9790360.331530, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (922380000, 9790360.331530, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (922380000, 9790360.331530, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (922380000, 9790360.331530, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (922380000, 9790360.331530, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (922380000, 9790360.331530, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 102084984531.0, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+        (922380000, 11938805.97080, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (922380000, 11938805.97080, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    #refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
 if __name__ == "__main__":
     nose.runmodule()
 

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -562,8 +562,6 @@ def test_convint_get_inventory_df(db, fname, backend):
     cal = com.get_inventory_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
-    print(cal)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803),
         (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803),
@@ -571,6 +569,32 @@ def test_convint_get_inventory_df(db, fname, backend):
         (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803),
         (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885),
         (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327)
+    ], dtype=ensure_dt_bytes([
+        ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+    
+    cal = com.get_inventory_df(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239', '92235'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    print(cal)
+
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534),
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 ),
+        (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803 ),
+        (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442 ),
+        (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534),
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803 ),
+        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442 ),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885 ),
+        (15, 'Reactor1', 4, 'core',  922350000, 0.04            ),
+        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664 ),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327 )
     ], dtype=ensure_dt_bytes([
         ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
         ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -246,15 +246,18 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
         (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 0.0444814879803, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId',
+                                            '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto',
+                              'O'), ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     #refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
     # test multiple nuclide selection
-    cal = com.get_transaction_nuc_df(myEval, nuc_list=['942390000', '922380000'])
+    cal = com.get_transaction_nuc_df(
+        myEval, nuc_list=['942390000', '922380000'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
     cal = cal.drop('TransactionId', 1)
@@ -279,8 +282,10 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
         (922380000, 0.9600000000000, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 0.9600000000000, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId',
+                                            '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto',
+                              'O'), ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     #refs.index = refs.index.astype('str')
@@ -314,15 +319,17 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
         (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 102084984531.0, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId',
+                                                '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto',
+                              'O'), ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
-    #refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
     # test multiple nuclide selection
-    cal = com.get_transaction_activity_df(myEval, nuc_list=['942390000', '922380000'])
+    cal = com.get_transaction_activity_df(
+        myEval, nuc_list=['942390000', '922380000'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
     cal = cal.drop('TransactionId', 1)
@@ -347,23 +354,87 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
         (922380000, 11938805.97080, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 11938805.97080, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId',
+                                                '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto',
+                              'O'), ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
-    #refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
+
+
+@dbtest
+def test_convint_get_transaction_decayheat_df(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_decayheat_df(myEval)
+
+    exp_head = ['SimId', 'ResourceId', 'NucId', 'DecayHeat', 'ReceiverId', 'ReceiverProto',
+                'SenderId', 'SenderProto', 'TransactionId', 'Commodity', 'Time']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    # test single nuclide selection
+    cal = com.get_transaction_decayheat_df(myEval, nuc_list=['942390000'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 3.34065303191e+30, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId',
+                                                '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto',
+                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+    # test multiple nuclide selection
+    cal = com.get_transaction_decayheat_df(
+        myEval, nuc_list=['942390000', '922380000'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    # SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1)
+    # SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1)
+
+    refs = pd.DataFrame(np.array([
+        (922380000, 2.609253035160e26, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (922380000, 2.609253035160e26, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (922380000, 2.609253035160e26, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (922380000, 2.609253035160e26, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (922380000, 2.609253035160e26, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (922380000, 2.609253035160e26, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (922380000, 2.609253035160e26, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+        (942390000, 3.34065303191e+30, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
+        (922380000, 3.18184057182e+26, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (922380000, 3.18184057182e+26, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+    ], dtype=ensure_dt_bytes([
+        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId',
+                                                '<i8'), ('ReceiverProto', 'O'),
+        ('SenderId', '<i8'), ('SenderProto',
+                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+
 if __name__ == "__main__":
     nose.runmodule()
 
 
-#[left]:  [6, 0, 2, 5, 1, 4, 8, 3, 7]
-#[left]:  [6, 0, 1, 4, 2, 5, 7, 3, 8]
-#[right]: [6, 0, 2, 5, 1, 4, 8, 3, 7]
-
-#@dbtest
-# def test_resources(db, fname, backend):
-#    r = root_metrics.resources(db=db)
-#    obs = r()
-#    assert_less(0, len(obs))
-#    assert_equal('Resources', r.name)

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -428,7 +428,46 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
     assert_frame_equal(cal, refs)
 
 
+@dbtest
+def test_convint_get_transaction_timeserie(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_timeseries(myEval)
+
+    exp_head = ['Time', 'Mass']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    # test single nuclide selection
+    cal = com.get_transaction_timeseries(myEval, nuc_list=['942390000'])
+    refs = pd.DataFrame(np.array([
+        (0, 0.000000000),
+        (1, 0.0444814879803),
+        (2, 0.0889629759607),
+        (3, 0.0889629759607),
+        (4, 0.0889629759607),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Mass', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+    # test multiple nuclide selection
+    cal = com.get_transaction_timeseries(
+        myEval, nuc_list=['942390000', '922380000'])
+    print(cal)
+    refs = pd.DataFrame(np.array([
+        (0, 0.000000000),
+        (1, 0.831724864011),
+        (2, 1.66344972802),
+        (3, 2.62344972802),
+        (4, 2.62344972802),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Mass', '<f8')
+    ]))
+    )
+
+    assert_frame_equal(cal, refs)
+
+
 if __name__ == "__main__":
     nose.runmodule()
-
-

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -19,36 +19,44 @@ import cymetric as cym
 from cymetric import convenient_interface as com
 from cymetric.tools import raw_to_series, ensure_dt_bytes
 
-def test_convint_gettransactiondf():
-    db = cym.dbopen(example_path)
+@dbtest
+def test_convint_gettransactiondf(db,fname,backend):
+    #db = cym.dbopen()
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_df(myEval)
+    
+    exp_head = ['SimId', 'ReceiverId', 'ReceiverProto',
+                'SenderId', 'SenderProto', 'TransactionId',
+                'ResourceId', 'Commodity', 'Time']
 
+    assert_equal(list(cal), exp_head)
+
+    cal = cal.drop('SimId', 1) #SimId change at each test need to drop it
+    cal = cal.drop('TransactionId', 1) #SimId change at each test need to drop it
+    cal = cal.drop('ResourceId', 1) #SimId change at each test need to drop it
+    
     refs = pd.DataFrame(np.array([
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
-         'Reactor1', 13, 'UOX_Source', 8, 78, 'uox', 4),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
-         'Reactor1', 14, 'MOX_Source', 0, 8,  'mox', 1),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
-         'Reactor1', 14, 'MOX_Source', 1, 23, 'mox', 2),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
-         'Reactor1', 14, 'MOX_Source', 3, 47, 'mox', 3),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 16,
-         'Reactor2', 14, 'MOX_Source', 2, 25, 'mox', 2),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 16,
-         'Reactor2', 14, 'MOX_Source', 4, 49, 'mox', 3),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 16,
-         'Reactor2', 14, 'MOX_Source', 6, 74, 'mox', 4),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 17,
-         'Reactor3', 13, 'UOX_Source', 5, 51, 'uox', 3),
-        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 17,
-         'Reactor3', 14, 'MOX_Source', 7, 76, 'mox', 4),
+        (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
+        (15, 'Reactor1', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 2),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 3),
+        (16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
+        (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
+        (17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype = ensure_dt_bytes([
-        ('SimId', 'O'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), 
-        ('SenderId', '<i8'), ('SenderProto', 'O'), ('TransactionId', '<i8'),
-        ('ResourceId', '<i8'), ('Commodity', 'O'), ('Time', '<i8')
+        ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), ('SenderId', '<i8'),
+        ('SenderProto', 'O'), ('Commodity', 'O'), ('Time', '<i8')
         ]))
     )
+    refs.index = refs.index.astype('str')
+    assert_frame_equal(cal, refs)
+
+
+#[left]:  [6, 0, 2, 5, 1, 4, 8, 3, 7]
+#[left]:  [6, 0, 1, 4, 2, 5, 7, 3, 8]
+#[right]: [6, 0, 2, 5, 1, 4, 8, 3, 7]
 
 #@dbtest
 #def test_resources(db, fname, backend):

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -655,6 +655,57 @@ def test_convint_get_inventory_activity_df(db, fname, backend):
 
 
 
+@dbtest
+def test_convint_get_inventory_decayheat_df(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_inventory_decayheat_df(myEval)
+
+    exp_head = ['SimId', 'AgentId', 'Prototype', 'Time', 'InventoryName',
+            'NucId', 'Quantity', 'Activity', 'DecayHeat']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    cal = com.get_inventory_decayheat_df(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442, 9.71016906463e+12, 3.17757855136e+32),
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885, 1.94203381293e+13, 6.35515710272e+32),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327, 2.91305071939e+13, 9.53273565408e+32)
+    ], dtype=ensure_dt_bytes([
+        ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
+        ('Activity', '<f8'), ('DecayHeat', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+    cal = com.get_inventory_decayheat_df(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239', '92235'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534, 29671782.9213    , 8.65609466244e+26),
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534, 29671782.9213    , 8.65609466244e+26),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212, 166272852.378    , 4.85064734329e+27),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442 , 9.71016906463e+12, 3.17757855136e+32),
+        (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534, 29671782.9213    , 8.65609466244e+26),
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442 , 332545704.756    , 9.70129468658e+27),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885 , 1.94203381293e+13, 6.35515710272e+32),
+        (15, 'Reactor1', 4, 'core',  922350000, 0.04            , 751553292.748    , 2.19249259917e+28),
+        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664 , 498818557.134    , 1.45519420299e+28),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327 , 2.91305071939e+13, 9.53273565408e+32)
+    ], dtype=ensure_dt_bytes([
+        ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
+        ('Activity', '<f8'), ('DecayHeat', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
 
 
 

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -24,10 +24,8 @@ from cymetric.tools import raw_to_series, ensure_dt_bytes
 def test_convint_get_transaction_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_df(myEval)
-
     exp_head = ['SimId', 'ReceiverId', 'ReceiverProto', 'SenderId',
                 'SenderProto', 'TransactionId', 'ResourceId', 'Commodity', 'Time']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
@@ -35,7 +33,6 @@ def test_convint_get_transaction_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -56,13 +53,11 @@ def test_convint_get_transaction_df(db, fname, backend):
 
     # test single sender
     cal = com.get_transaction_df(myEval, send_list=['UOX_Source'])
-
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
@@ -77,13 +72,11 @@ def test_convint_get_transaction_df(db, fname, backend):
     # test multiple sender
     cal = com.get_transaction_df(
         myEval, send_list=['UOX_Source', 'MOX_Source'])
-
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -104,13 +97,11 @@ def test_convint_get_transaction_df(db, fname, backend):
 
     # test single receiver
     cal = com.get_transaction_df(myEval, rec_list=['Reactor1'])
-
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     # SimId change at each test need to drop it
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -131,7 +122,6 @@ def test_convint_get_transaction_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -147,8 +137,7 @@ def test_convint_get_transaction_df(db, fname, backend):
     refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
-
-# test multiple sender and multiple receiver
+    # test multiple sender and multiple receiver
     cal = com.get_transaction_df(myEval, send_list=['UOX_Source', 'MOX_Source'],
                                  rec_list=['Reactor1', 'Reactor2'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
@@ -156,7 +145,6 @@ def test_convint_get_transaction_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -180,7 +168,6 @@ def test_convint_get_transaction_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
@@ -199,7 +186,6 @@ def test_convint_get_transaction_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
         (15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -223,10 +209,8 @@ def test_convint_get_transaction_df(db, fname, backend):
 def test_convint_get_transaction_nuc_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_nuc_df(myEval)
-
     exp_head = ['SimId', 'ResourceId', 'NucId', 'Mass', 'ReceiverId', 'ReceiverProto',
                 'SenderId', 'SenderProto', 'TransactionId', 'Commodity', 'Time']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     # test single nuclide selection
@@ -236,7 +220,6 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
@@ -251,7 +234,7 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
         ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
-    #refs.index = refs.index.astype('str')
+    # refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
     # test multiple nuclide selection
@@ -262,7 +245,6 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (922380000, 0.7872433760310, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 0.0444814879803, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -286,7 +268,7 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
         ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
-    #refs.index = refs.index.astype('str')
+    # refs.index = refs.index.astype('str')
     assert_frame_equal(cal, refs)
 
 
@@ -294,10 +276,8 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
 def test_convint_get_transaction_activity_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_activity_df(myEval)
-
     exp_head = ['SimId', 'ResourceId', 'NucId', 'Activity', 'ReceiverId', 'ReceiverProto',
                 'SenderId', 'SenderProto', 'TransactionId', 'Commodity', 'Time']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     # test single nuclide selection
@@ -307,7 +287,6 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 102084984531.0, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
@@ -317,7 +296,7 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
         (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 102084984531.0, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId','<i8'),
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId', '<i8'),
         ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
         ('Commodity', 'O'), ('Time', '<i8')
     ]))
@@ -351,7 +330,7 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
         (922380000, 11938805.97080, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 11938805.97080, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId','<i8'),
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId', '<i8'),
         ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
         ('Commodity', 'O'), ('Time', '<i8')
     ]))
@@ -363,10 +342,8 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
 def test_convint_get_transaction_decayheat_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_transaction_decayheat_df(myEval)
-
     exp_head = ['SimId', 'ResourceId', 'NucId', 'DecayHeat', 'ReceiverId', 'ReceiverProto',
                 'SenderId', 'SenderProto', 'TransactionId', 'Commodity', 'Time']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     # test single nuclide selection
@@ -376,7 +353,6 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 2),
@@ -386,7 +362,7 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
         (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 3.34065303191e+30, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId','<i8'),
+        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId', '<i8'),
         ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
         ('Commodity', 'O'), ('Time', '<i8')
     ]))
@@ -401,7 +377,6 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
     cal = cal.drop('TransactionId', 1)
     # SimId change at each test need to drop it
     cal = cal.drop('ResourceId', 1)
-
     refs = pd.DataFrame(np.array([
         (922380000, 2.609253035160e26, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
         (942390000, 3.34065303191e+30, 15, 'Reactor1', 14, 'MOX_Source', 'mox', 1),
@@ -420,7 +395,7 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
         (922380000, 3.18184057182e+26, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 3.18184057182e+26, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId','<i8'),
+        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId', '<i8'),
         ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
         ('Commodity', 'O'), ('Time', '<i8')
     ]))
@@ -431,14 +406,12 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
 @dbtest
 def test_convint_get_transaction_timeserie(db, fname, backend):
     myEval = cym.Evaluator(db)
-    cal = com.get_transaction_timeseries(myEval)
-
+    cal = com.get_transaction_timeserie(myEval)
     exp_head = ['Time', 'Mass']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     # test single nuclide selection
-    cal = com.get_transaction_timeseries(myEval, nuc_list=['942390000'])
+    cal = com.get_transaction_timeserie(myEval, nuc_list=['942390000'])
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
         (1, 0.0444814879803),
@@ -452,7 +425,7 @@ def test_convint_get_transaction_timeserie(db, fname, backend):
     assert_frame_equal(cal, refs)
 
     # test multiple nuclide selection
-    cal = com.get_transaction_timeseries(
+    cal = com.get_transaction_timeserie(
         myEval, nuc_list=['942390000', '922380000'])
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
@@ -464,21 +437,18 @@ def test_convint_get_transaction_timeserie(db, fname, backend):
         ('Time', '<i8'), ('Mass', '<f8')
     ]))
     )
-
     assert_frame_equal(cal, refs)
 
 
 @dbtest
 def test_convint_get_transaction_activity_timeserie(db, fname, backend):
     myEval = cym.Evaluator(db)
-    cal = com.get_transaction_activity_timeseries(myEval)
-
+    cal = com.get_transaction_activity_timeserie(myEval)
     exp_head = ['Time', 'Activity']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     # test single nuclide selection
-    cal = com.get_transaction_activity_timeseries(
+    cal = com.get_transaction_activity_timeserie(
         myEval, nuc_list=['942390000'])
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
@@ -493,7 +463,7 @@ def test_convint_get_transaction_activity_timeserie(db, fname, backend):
     assert_frame_equal(cal, refs)
 
     # test multiple nuclide selection
-    cal = com.get_transaction_activity_timeseries(
+    cal = com.get_transaction_activity_timeserie(
         myEval, nuc_list=['942390000', '922380000'])
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
@@ -505,20 +475,18 @@ def test_convint_get_transaction_activity_timeserie(db, fname, backend):
         ('Time', '<i8'), ('Activity', '<f8')
     ]))
     )
-
     assert_frame_equal(cal, refs)
+
 
 @dbtest
 def test_convint_get_transaction_decayheat_timeserie(db, fname, backend):
     myEval = cym.Evaluator(db)
-    cal = com.get_transaction_decayheat_timeseries(myEval)
-
+    cal = com.get_transaction_decayheat_timeserie(myEval)
     exp_head = ['Time', 'DecayHeat']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     # test single nuclide selection
-    cal = com.get_transaction_decayheat_timeseries(
+    cal = com.get_transaction_decayheat_timeserie(
         myEval, nuc_list=['942390000'])
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
@@ -533,7 +501,7 @@ def test_convint_get_transaction_decayheat_timeserie(db, fname, backend):
     assert_frame_equal(cal, refs)
 
     # test multiple nuclide selection
-    cal = com.get_transaction_decayheat_timeseries(
+    cal = com.get_transaction_decayheat_timeserie(
         myEval, nuc_list=['942390000', '922380000'])
     refs = pd.DataFrame(np.array([
         (0, 0.000000000),
@@ -545,7 +513,6 @@ def test_convint_get_transaction_decayheat_timeserie(db, fname, backend):
         ('Time', '<i8'), ('DecayHeat', '<f8')
     ]))
     )
-
     assert_frame_equal(cal, refs)
 
 
@@ -553,10 +520,8 @@ def test_convint_get_transaction_decayheat_timeserie(db, fname, backend):
 def test_convint_get_inventory_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_inventory_df(myEval)
-
     exp_head = ['SimId', 'AgentId', 'Prototype',
                 'Time', 'InventoryName', 'NucId', 'Quantity']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     cal = com.get_inventory_df(myEval, fac_list=['Reactor1'],
@@ -575,24 +540,24 @@ def test_convint_get_inventory_df(db, fname, backend):
     ]))
     )
     assert_frame_equal(cal, refs)
-    
+
     cal = com.get_inventory_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239', '92235'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534),
-        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 ),
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803),
         (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534),
-        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803 ),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803),
         (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212),
-        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442 ),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442),
         (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534),
-        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803 ),
-        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442 ),
-        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885 ),
-        (15, 'Reactor1', 4, 'core',  922350000, 0.04            ),
-        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664 ),
-        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327 )
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803),
+        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885),
+        (15, 'Reactor1', 4, 'core',  922350000, 0.04),
+        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327)
     ], dtype=ensure_dt_bytes([
         ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
         ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8')
@@ -605,21 +570,24 @@ def test_convint_get_inventory_df(db, fname, backend):
 def test_convint_get_inventory_activity_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_inventory_activity_df(myEval)
-
     exp_head = ['SimId', 'AgentId', 'Prototype', 'Time', 'InventoryName',
             'NucId', 'Quantity', 'Activity']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     cal = com.get_inventory_activity_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
-        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803, 2.44036364223e+13),
-        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803, 2.44036364223e+13),
-        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442, 9.71016906463e+12),
-        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803, 2.44036364223e+13),
-        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885, 1.94203381293e+13),
+        (15, 'Reactor1', 1, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'spent', 942390000,
+         0.0176991150442, 9.71016906463e+12),
+        (15, 'Reactor1', 3, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 3, 'spent', 942390000,
+         0.0353982300885, 1.94203381293e+13),
         (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327, 2.91305071939e+13)
     ], dtype=ensure_dt_bytes([
         ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
@@ -628,23 +596,29 @@ def test_convint_get_inventory_activity_df(db, fname, backend):
     ]))
     )
     assert_frame_equal(cal, refs)
+
     cal = com.get_inventory_activity_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239', '92235'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
-        (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534, 29671782.9213    ),
-        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13),
-        (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534, 29671782.9213    ),
-        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13),
-        (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212, 166272852.378    ),
-        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442 , 9.71016906463e+12),
-        (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534, 29671782.9213    ),
-        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13),
-        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442 , 332545704.756    ),
-        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885 , 1.94203381293e+13),
-        (15, 'Reactor1', 4, 'core',  922350000, 0.04            , 751553292.748    ),
-        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664 , 498818557.134    ),
-        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327 , 2.91305071939e+13)
+        (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534, 29671782.9213),
+        (15, 'Reactor1', 1, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534, 29671782.9213),
+        (15, 'Reactor1', 2, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212, 166272852.378),
+        (15, 'Reactor1', 2, 'spent', 942390000,
+         0.0176991150442, 9.71016906463e+12),
+        (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534, 29671782.9213),
+        (15, 'Reactor1', 3, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442, 332545704.756),
+        (15, 'Reactor1', 3, 'spent', 942390000,
+         0.0353982300885, 1.94203381293e+13),
+        (15, 'Reactor1', 4, 'core',  922350000, 0.04, 751553292.748),
+        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664, 498818557.134),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327, 2.91305071939e+13)
     ], dtype=ensure_dt_bytes([
         ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
         ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
@@ -654,27 +628,30 @@ def test_convint_get_inventory_activity_df(db, fname, backend):
     assert_frame_equal(cal, refs)
 
 
-
 @dbtest
 def test_convint_get_inventory_decayheat_df(db, fname, backend):
     myEval = cym.Evaluator(db)
     cal = com.get_inventory_decayheat_df(myEval)
-
     exp_head = ['SimId', 'AgentId', 'Prototype', 'Time', 'InventoryName',
             'NucId', 'Quantity', 'Activity', 'DecayHeat']
-
     assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
     cal = com.get_inventory_decayheat_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
-        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
-        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
-        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442, 9.71016906463e+12, 3.17757855136e+32),
-        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
-        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885, 1.94203381293e+13, 6.35515710272e+32),
-        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327, 2.91305071939e+13, 9.53273565408e+32)
+        (15, 'Reactor1', 1, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'spent', 942390000,
+         0.0176991150442, 9.71016906463e+12, 3.17757855136e+32),
+        (15, 'Reactor1', 3, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 3, 'spent', 942390000,
+         0.0353982300885, 1.94203381293e+13, 6.35515710272e+32),
+        (15, 'Reactor1', 4, 'spent', 942390000,
+         0.0530973451327, 2.91305071939e+13, 9.53273565408e+32)
     ], dtype=ensure_dt_bytes([
         ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
         ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
@@ -682,23 +659,37 @@ def test_convint_get_inventory_decayheat_df(db, fname, backend):
     ]))
     )
     assert_frame_equal(cal, refs)
+
     cal = com.get_inventory_decayheat_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239', '92235'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
     refs = pd.DataFrame(np.array([
-        (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534, 29671782.9213    , 8.65609466244e+26),
-        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13, 7.98590335085e+32),
-        (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534, 29671782.9213    , 8.65609466244e+26),
-        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13, 7.98590335085e+32),
-        (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212, 166272852.378    , 4.85064734329e+27),
-        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442 , 9.71016906463e+12, 3.17757855136e+32),
-        (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534, 29671782.9213    , 8.65609466244e+26),
-        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13, 7.98590335085e+32),
-        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442 , 332545704.756    , 9.70129468658e+27),
-        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885 , 1.94203381293e+13, 6.35515710272e+32),
-        (15, 'Reactor1', 4, 'core',  922350000, 0.04            , 751553292.748    , 2.19249259917e+28),
-        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664 , 498818557.134    , 1.45519420299e+28),
-        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327 , 2.91305071939e+13, 9.53273565408e+32)
+        (15, 'Reactor1', 1, 'core',  922350000,
+         0.00157922442534, 29671782.9213, 8.65609466244e+26),
+        (15, 'Reactor1', 1, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'core',  922350000,
+         0.00157922442534, 29671782.9213, 8.65609466244e+26),
+        (15, 'Reactor1', 2, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 2, 'spent', 922350000,
+         0.00884955752212, 166272852.378, 4.85064734329e+27),
+        (15, 'Reactor1', 2, 'spent', 942390000,
+         0.0176991150442, 9.71016906463e+12, 3.17757855136e+32),
+        (15, 'Reactor1', 3, 'core',  922350000,
+         0.00157922442534, 29671782.9213, 8.65609466244e+26),
+        (15, 'Reactor1', 3, 'core',  942390000,
+         0.0444814879803, 2.44036364223e+13, 7.98590335085e+32),
+        (15, 'Reactor1', 3, 'spent', 922350000,
+         0.0176991150442, 332545704.756, 9.70129468658e+27),
+        (15, 'Reactor1', 3, 'spent', 942390000,
+         0.0353982300885, 1.94203381293e+13, 6.35515710272e+32),
+        (15, 'Reactor1', 4, 'core',  922350000,
+         0.04, 751553292.748, 2.19249259917e+28),
+        (15, 'Reactor1', 4, 'spent', 922350000,
+         0.0265486725664, 498818557.134, 1.45519420299e+28),
+        (15, 'Reactor1', 4, 'spent', 942390000,
+         0.0530973451327, 2.91305071939e+13, 9.53273565408e+32)
     ], dtype=ensure_dt_bytes([
         ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
         ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
@@ -708,13 +699,112 @@ def test_convint_get_inventory_decayheat_df(db, fname, backend):
     assert_frame_equal(cal, refs)
 
 
+@dbtest
+def test_convint_get_inventory_timeserie(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_inventory_timeserie(myEval)
+    exp_head = ['Time', 'Quantity']
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    cal = com.get_inventory_timeserie(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239'])
+    refs = pd.DataFrame(np.array([
+        (0, 0.0            ),
+        (1, 0.0444814879803),
+        (2, 0.0621806030246),
+        (3, 0.0798797180688),
+        (4, 0.0530973451327)
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Quantity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+    cal=com.get_inventory_timeserie(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239', '92235'])
+    refs=pd.DataFrame(np.array([
+        (0, 0.0            ),
+        (1, 0.0460607124057),
+        (2, 0.0726093849721),
+        (3, 0.0991580575384),
+        (4, 0.119646017699 )
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Quantity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
 
 
+@dbtest
+def test_convint_get_inventory_activity_timeserie(db, fname, backend):
+    myEval=cym.Evaluator(db)
+    cal=com.get_inventory_activity_timeserie(myEval)
+    exp_head=['Time', 'Activity']
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    cal=com.get_inventory_activity_timeserie(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239'])
+    refs=pd.DataFrame(np.array([
+        (0, 0.0             ),
+        (1, 2.44036364223e+13),
+        (2, 3.41138054869e+13),
+        (3, 4.38239745515e+13),
+        (4, 2.91305071939e+13)
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Activity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+    cal=com.get_inventory_activity_timeserie(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239', '92235'])
+    refs=pd.DataFrame(np.array([
+        (0, 0.0             ),
+        (1, 2.4403666094e+13),
+        (2, 3.41140014315e+13),
+        (3, 4.3824336769e+13),
+        (4, 2.91317575657e+13),
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('Activity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
 
 
+@dbtest
+def test_convint_get_inventory_decayheat_timeserie(db, fname, backend):
+    myEval=cym.Evaluator(db)
+    cal=com.get_inventory_decayheat_timeserie(myEval)
+    exp_head=['Time', 'DecayHeat']
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
 
+    cal=com.get_inventory_decayheat_timeserie(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239'])
+    refs=pd.DataFrame(np.array([
+        (0, 0.0             ),
+        (1, 7.98590335085e+32),
+        (2, 1.11634819022e+33),
+        (3, 1.43410604536e+33),
+        (4, 9.53273565408e+32)
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('DecayHeat', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
 
-
+    cal=com.get_inventory_decayheat_timeserie(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239', '92235'])
+    refs=pd.DataFrame(np.array([
+        (0, 0.0             ),
+        (1, 7.98591200694e+32),
+        (2, 1.11635390648e+33),
+        (3, 1.43411661226e+33),
+        (4, 9.53310042276e+32)
+    ], dtype=ensure_dt_bytes([
+        ('Time', '<i8'), ('DecayHeat', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
 
 
 if __name__ == "__main__":

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -246,10 +246,9 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
         (942390000, 0.0444814879803, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 0.0444814879803, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId',
-                                            '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto',
-                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'),
+        ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
+        ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     #refs.index = refs.index.astype('str')
@@ -282,10 +281,9 @@ def test_convint_get_transaction_nuc_df(db, fname, backend):
         (922380000, 0.9600000000000, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 0.9600000000000, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId',
-                                            '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto',
-                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Mass', '<f8'), ('ReceiverId', '<i8'),
+        ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
+        ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     #refs.index = refs.index.astype('str')
@@ -319,10 +317,9 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
         (942390000, 102084984531.0, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 102084984531.0, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId',
-                                                '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto',
-                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId','<i8'),
+        ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
+        ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     assert_frame_equal(cal, refs)
@@ -354,10 +351,9 @@ def test_convint_get_transaction_activity_df(db, fname, backend):
         (922380000, 11938805.97080, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 11938805.97080, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId',
-                                                '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto',
-                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('Activity', '<f8'), ('ReceiverId','<i8'),
+        ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
+        ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     assert_frame_equal(cal, refs)
@@ -390,10 +386,9 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
         (942390000, 3.34065303191e+30, 16, 'Reactor2', 14, 'MOX_Source', 'mox', 4),
         (942390000, 3.34065303191e+30, 17, 'Reactor3', 14, 'MOX_Source', 'mox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId',
-                                                '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto',
-                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId','<i8'),
+        ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
+        ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     assert_frame_equal(cal, refs)
@@ -425,10 +420,9 @@ def test_convint_get_transaction_decayheat_df(db, fname, backend):
         (922380000, 3.18184057182e+26, 17, 'Reactor3', 13, 'UOX_Source', 'uox', 3),
         (922380000, 3.18184057182e+26, 15, 'Reactor1', 13, 'UOX_Source', 'uox', 4),
     ], dtype=ensure_dt_bytes([
-        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId',
-                                                '<i8'), ('ReceiverProto', 'O'),
-        ('SenderId', '<i8'), ('SenderProto',
-                              'O'), ('Commodity', 'O'), ('Time', '<i8')
+        ('NucId', '<i8'), ('DecayHeat', '<f8'), ('ReceiverId','<i8'),
+        ('ReceiverProto', 'O'), ('SenderId', '<i8'), ('SenderProto', 'O'),
+        ('Commodity', 'O'), ('Time', '<i8')
     ]))
     )
     assert_frame_equal(cal, refs)

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -1,0 +1,62 @@
+"""Tests for convinient interface method"""
+from __future__ import print_function, unicode_literals
+from uuid import UUID
+import os
+import subprocess
+from functools import wraps
+
+import nose
+from nose.tools import assert_equal, assert_less
+
+import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+
+
+from tools import setup, dbtest
+
+import cymetric as cym
+from cymetric import convenient_interface as com
+from cymetric.tools import raw_to_series, ensure_dt_bytes
+
+def test_convint_gettransactiondf():
+    db = cym.dbopen(example_path)
+    myEval = cym.Evaluator(db)
+    cal = com.get_transaction_df(myEval)
+
+    refs = pd.DataFrame(np.array([
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
+         'Reactor1', 13, 'UOX_Source', 8, 78, 'uox', 4),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
+         'Reactor1', 14, 'MOX_Source', 0, 8,  'mox', 1),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
+         'Reactor1', 14, 'MOX_Source', 1, 23, 'mox', 2),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 15,
+         'Reactor1', 14, 'MOX_Source', 3, 47, 'mox', 3),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 16,
+         'Reactor2', 14, 'MOX_Source', 2, 25, 'mox', 2),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 16,
+         'Reactor2', 14, 'MOX_Source', 4, 49, 'mox', 3),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 16,
+         'Reactor2', 14, 'MOX_Source', 6, 74, 'mox', 4),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 17,
+         'Reactor3', 13, 'UOX_Source', 5, 51, 'uox', 3),
+        (UUID('4485c97d-59bc-4eda-ad42-63a7f042053a'), 17,
+         'Reactor3', 14, 'MOX_Source', 7, 76, 'mox', 4),
+    ], dtype = ensure_dt_bytes([
+        ('SimId', 'O'), ('ReceiverId', '<i8'), ('ReceiverProto', 'O'), 
+        ('SenderId', '<i8'), ('SenderProto', 'O'), ('TransactionId', '<i8'),
+        ('ResourceId', '<i8'), ('Commodity', 'O'), ('Time', '<i8')
+        ]))
+    )
+
+#@dbtest
+#def test_resources(db, fname, backend):
+#    r = root_metrics.resources(db=db)
+#    obs = r()
+#    assert_less(0, len(obs))
+#    assert_equal('Resources', r.name)
+
+
+if __name__ == "__main__":
+    nose.runmodule()

--- a/tests/test_conv_int.py
+++ b/tests/test_conv_int.py
@@ -579,8 +579,6 @@ def test_convint_get_inventory_df(db, fname, backend):
     cal = com.get_inventory_df(myEval, fac_list=['Reactor1'],
                                nuc_list=['94239', '92235'])
     cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
-    print(cal)
-
     refs = pd.DataFrame(np.array([
         (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534),
         (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 ),
@@ -601,6 +599,71 @@ def test_convint_get_inventory_df(db, fname, backend):
     ]))
     )
     assert_frame_equal(cal, refs)
+
+
+@dbtest
+def test_convint_get_inventory_activity_df(db, fname, backend):
+    myEval = cym.Evaluator(db)
+    cal = com.get_inventory_activity_df(myEval)
+
+    exp_head = ['SimId', 'AgentId', 'Prototype', 'Time', 'InventoryName',
+            'NucId', 'Quantity', 'Activity']
+
+    assert_equal(list(cal), exp_head)  # CHeck we have the correct headers
+
+    cal = com.get_inventory_activity_df(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442, 9.71016906463e+12),
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803, 2.44036364223e+13),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885, 1.94203381293e+13),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327, 2.91305071939e+13)
+    ], dtype=ensure_dt_bytes([
+        ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
+        ('Activity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+    cal = com.get_inventory_activity_df(myEval, fac_list=['Reactor1'],
+                               nuc_list=['94239', '92235'])
+    cal = cal.drop('SimId', 1)  # SimId change at each test need to drop it
+    refs = pd.DataFrame(np.array([
+        (15, 'Reactor1', 1, 'core',  922350000, 0.00157922442534, 29671782.9213    ),
+        (15, 'Reactor1', 1, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'core',  922350000, 0.00157922442534, 29671782.9213    ),
+        (15, 'Reactor1', 2, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13),
+        (15, 'Reactor1', 2, 'spent', 922350000, 0.00884955752212, 166272852.378    ),
+        (15, 'Reactor1', 2, 'spent', 942390000, 0.0176991150442 , 9.71016906463e+12),
+        (15, 'Reactor1', 3, 'core',  922350000, 0.00157922442534, 29671782.9213    ),
+        (15, 'Reactor1', 3, 'core',  942390000, 0.0444814879803 , 2.44036364223e+13),
+        (15, 'Reactor1', 3, 'spent', 922350000, 0.0176991150442 , 332545704.756    ),
+        (15, 'Reactor1', 3, 'spent', 942390000, 0.0353982300885 , 1.94203381293e+13),
+        (15, 'Reactor1', 4, 'core',  922350000, 0.04            , 751553292.748    ),
+        (15, 'Reactor1', 4, 'spent', 922350000, 0.0265486725664 , 498818557.134    ),
+        (15, 'Reactor1', 4, 'spent', 942390000, 0.0530973451327 , 2.91305071939e+13)
+    ], dtype=ensure_dt_bytes([
+        ('AgentId', '<i8'), ('Prototype', 'O'), ('Time', '<i8'),
+        ('InventoryName', 'O'), ('NucId', '<i8'), ('Quantity', '<f8'),
+        ('Activity', '<f8')
+    ]))
+    )
+    assert_frame_equal(cal, refs)
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR aims to bring some convenient/easy methods to perform analysis on `Cyclus` output data in the `Cyclus` post-prossessing library, `Cymetric`. The accessible informations accessible using cymetric are the **grey** bubble, which need to be combined to get easily  understandable informations (like mass of U238 exchanged between 2 facilities as a function of the time).
This allows users to get directly those informations without have to manipulate Panda Data Frames.
You can find [here](https://github.com/bam241/cymetric_play/blob/master/conv_int.ipynb) an small python notebook demonstrating some of this.

2 kind of pandas Data Frame can be returned:
- the `_df` methods return a complicated panda data frame containing a lot of informations.
- the `_timeseries` methods return a simple time-serie (time vs value) that is easy to understand/analyze/plot, if a single time occurs many time a sum is performed.

In **light green** are the "standalone" methods return directly time-series formatted from the `Cyclus` output data.

In **blue** and **dark green**, the method are slightly more complicated, they need to combine multiple informations from the the output file to produce the time series.

The data required to combine those are represented in **light-grey** bubble on the graph, and corresponds to the `evaler_.eval('XXXXXXX')` line in the different methods, which return a panda Data Frame containing the information.

Those methods (**blue** and **dark green**)  can be organized into 2 categories the inventories related methods and the transactions related methods. Because of the way those informations are written in the cycles output file they cannot be treated exactly in the same way.
If both corresponds to a list of materials (mass and isotopic compositions), either exchanged or stored in a facility, evolving during the simulation (time), the inventories tables contains already the isotopic composition of the different materials, and the transaction tables refers to the `materials` table which contains the isotopic compositions.
In the same way, `Cymetric` (this analysis tool) already includes ways to compute Activity and DecayHeat tables for the transaction, but not for the inventories.


Finally the **red** bubbles correspond to generic functions that are used multiple time. They are used either to shape nuclide list in the proper format, or to perform transformation on Panda Data Frame.



![convienient](https://cloud.githubusercontent.com/assets/15145274/26217279/6877369e-3bcc-11e7-99b6-cb2f226d00d5.png)

 

Note: The unit test are not finished yet, only few of them are implemented.